### PR TITLE
Enforce unique bucket names with an extra Redis database

### DIFF
--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -580,6 +580,26 @@ use = egg:swift#s3api
 # You can override the default log routing for this filter here:
 # log_name = s3api
 
+# Enable the Redis-based bucket database. This will make the bucket names
+# globally unique, and will enable anonymous requests (provided that ACLs
+# are enabled and set to public-read for the requested object).
+# Notice that anonymous requests only work with virtual-hosted style
+# requests (you must define storage_domain) or by enabling
+# allow_anymous_path_request
+#
+# Default (disabled)
+#bucket_db_connection =
+#
+# IP address and port of a single Redis server.
+#bucket_db_connection = redis://127.0.0.1:6379?prefix=s3bucket%3A
+#
+# Sentinel-enabled Redis cluster.
+#bucket_db_connection = redis+sentinel://10.0.1.24:6012,10.0.1.27:6012,10.0.1.25:6012?sentinel_name=IAM-master-1&prefix=s3bucket%3A
+
+# Allow anymous request without virtual-hosted style
+# (bucket_db_enabled is required)
+#allow_anymous_path_request = true
+
 [filter:s3token]
 # s3token middleware authenticates with keystone using the s3 credentials
 # provided in the request header. Please put s3token between s3api

--- a/etc/s3-default.cfg
+++ b/etc/s3-default.cfg
@@ -56,8 +56,7 @@ storage_domain = localhost
 s3_acl = true
 check_bucket_owner = true
 # min_segment_size = 8
-bucket_db_enabled = true
-bucket_db_host = 127.0.0.1:6379
+bucket_db_connection = redis://127.0.0.1:6379
 
 [filter:tempauth]
 use = egg:swift#tempauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ cryptography>=2.0.2                     # BSD/Apache-2.0
 #
 # dnspython>=1.15.0;python_version=='2.7' # http://www.dnspython.org/LICENSE
 # ipaddress>=1.0.16;python_version<'3.3'  # PSF
+git+git://github.com/open-io/oio-sds.git#egg=oio

--- a/swift/common/middleware/s3api/bucket_db.py
+++ b/swift/common/middleware/s3api/bucket_db.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2020 OpenStack Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from swift.common.utils import config_true_value, parse_connection_string
+
+from oio.common.redis_conn import RedisConnection
+
+
+class DummyBucketDb(object):
+    """
+    Keep a list of buckets with their associated account.
+    Dummy in-memory implementation.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._bucket_db = dict()
+
+    def get_owner(self, bucket):
+        """
+        Get the owner of a bucket.
+        """
+        owner, deadline = self._bucket_db.get(bucket, (None, None))
+        if deadline is not None and deadline < time.time():
+            del self._bucket_db[bucket]
+            return None
+        return owner
+
+    def reserve(self, bucket, owner, timeout=30):
+        """
+        Reserve a bucket. The bucket entry must not already
+        exist in the database.
+
+        :param bucket: name of the bucket
+        :param owner: name of the account owning the bucket
+        :param timeout: a timeout in seconds, for the reservation to expire.
+        :returns: True if the bucket has been reserved, False otherwise
+        """
+        if self.get_owner(bucket):
+            return False
+        deadline = time.time() + timeout
+        self._bucket_db[bucket] = (owner, deadline)
+        return True
+
+    def set_owner(self, bucket, owner):
+        """
+        Set the owner of a bucket.
+
+        :param bucket: name of the bucket
+        :param owner: name of the account owning the bucket
+        :returns: True if the ownership has been set
+        """
+        self._bucket_db[bucket] = (owner, None)
+        return True
+
+    def release(self, bucket):
+        """
+        Remove the bucket from the database.
+        """
+        self._bucket_db.pop(bucket, None)
+
+
+class RedisBucketDb(RedisConnection):
+    """
+    Keep a list of buckets with their associated account.
+    """
+
+    def __init__(self, host=None, sentinel_hosts=None, sentinel_name=None,
+                 prefix="s3bucket:", **kwargs):
+        super(RedisBucketDb, self).__init__(
+            host=host, sentinel_hosts=sentinel_hosts,
+            sentinel_name=sentinel_name, **kwargs)
+        self._prefix = prefix
+
+    def _key(self, bucket):
+        return self._prefix + bucket
+
+    def get_owner(self, bucket):
+        """
+        Get the owner of a bucket.
+
+        :returns: the name of the account owning the bucket or None
+        """
+        owner = self.conn_slave.get(self._key(bucket))
+        return owner.decode('utf-8') if owner is not None else owner
+
+    def set_owner(self, bucket, owner):
+        """
+        Set the owner of a bucket.
+
+        :param bucket: name of the bucket
+        :param owner: name of the account owning the bucket
+        :returns: True if the ownership has been set
+        """
+        res = self.conn.set(self._key(bucket), owner.encode('utf-8'))
+        return res is True
+
+    def reserve(self, bucket, owner, timeout=30):
+        """
+        Reserve a bucket. The bucket entry must not already
+        exist in the database.
+
+        :param bucket: name of the bucket
+        :param owner: name of the account owning the bucket
+        :param timeout: a timeout in seconds, for the reservation to expire.
+        :returns: True if the bucket has been reserved, False otherwise
+        """
+        res = self.conn.set(self._key(bucket), owner.encode('utf-8'),
+                            ex=int(timeout), nx=True)
+        return res is True
+
+    def release(self, bucket):
+        """
+        Remove the bucket from the database.
+        """
+        self.conn.delete(self._key(bucket))
+
+
+class BucketDbWrapper(object):
+    """
+    Memoizer for bucket DB. It is intended to have the same life cycle
+    as an S3 request.
+    """
+
+    def __init__(self, bucket_db):
+        self.bucket_db = bucket_db
+        self.cache = dict()
+
+    def get_owner(self, bucket, **kwargs):
+        cached = self.cache.get(bucket)
+        if cached:
+            return cached
+        owner = self.bucket_db.get_owner(bucket=bucket, **kwargs)
+        self.cache[bucket] = owner
+        return owner
+
+    def set_owner(self, bucket, owner, **kwargs):
+        res = self.bucket_db.set_owner(bucket=bucket, owner=owner, **kwargs)
+        if res:
+            self.cache[bucket] = owner
+        return res
+
+    def release(self, bucket, **kwargs):
+        self.cache.pop(bucket, None)
+        return self.bucket_db.release(bucket=bucket, **kwargs)
+
+    def reserve(self, bucket, owner, **kwargs):
+        res = self.bucket_db.reserve(bucket=bucket, owner=owner, **kwargs)
+        if res:
+            self.cache[bucket] = owner
+        return res
+
+
+def get_bucket_db(conf):
+    """
+    If `bucket_db_connection` is set in `conf`, get an instance of the
+    appropriate bucket database class (RedisBucketDb or DummyBucketDb).
+    `bucket_db_connection` must be a URL with a scheme, a host and optional
+    parameters.
+    """
+    klass = None
+    conn_str = conf.get('bucket_db_connection')
+    if conn_str:
+        # New style configuration
+        scheme, netloc, db_kwargs = parse_connection_string(conn_str)
+        if scheme in ('redis', 'redis+sentinel'):
+            klass = RedisBucketDb
+            if scheme == 'redis+sentinel':
+                db_kwargs['sentinel_hosts'] = netloc
+            else:
+                db_kwargs['host'] = netloc
+        elif scheme == 'dummy':
+            klass = DummyBucketDb
+        else:
+            raise ValueError('bucket_db: unknown scheme: %r' % scheme)
+    else:
+        # Legacy configuration
+        db_kwargs = {k[10:]: v for k, v in conf.items()
+                     if k.startswith('bucket_db_')}
+        if config_true_value(db_kwargs.get('enabled', 'false')):
+            if 'host' in db_kwargs or 'sentinel_hosts' in db_kwargs:
+                klass = RedisBucketDb
+            else:
+                klass = DummyBucketDb
+    if klass:
+        return klass(**db_kwargs)
+    return None

--- a/swift/common/middleware/s3api/controllers/__init__.py
+++ b/swift/common/middleware/s3api/controllers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 OpenStack Foundation.
+# Copyright (c) 2014-2020 OpenStack Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,12 +33,15 @@ from swift.common.middleware.s3api.controllers.versioning import \
     VersioningController
 from swift.common.middleware.s3api.controllers.tagging import \
     TaggingController
+from swift.common.middleware.s3api.controllers.unique_bucket import \
+    UniqueBucketController
 
 __all__ = [
     'Controller',
     'ServiceController',
     'BucketController',
     'ObjectController',
+    'UniqueBucketController',
 
     'AclController',
     'S3AclController',

--- a/swift/common/middleware/s3api/controllers/unique_bucket.py
+++ b/swift/common/middleware/s3api/controllers/unique_bucket.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2018-2019 OpenIO SAS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from swift.common.utils import public
+from swift.common.middleware.s3api.controllers import BucketController
+from swift.common.middleware.s3api.s3response import BucketAlreadyExists, \
+    BucketAlreadyOwnedByYou, NoSuchBucket
+# from swift3.utils import log_s3api_command
+
+
+class UniqueBucketController(BucketController):
+    """
+    Handles bucket requests, ensure bucket names are globally unique.
+    """
+
+    @public
+    def PUT(self, req):
+        """
+        Handle PUT Bucket request
+        """
+        # log_s3api_command(req, 'create-bucket')
+        # We are about to create a container, reserve its name.
+        can_create = req.bucket_db.reserve(req.container_name, req.account)
+        if not can_create:
+            ct_owner = req.bucket_db.get_owner(req.container_name)
+            if ct_owner == req.account:
+                raise BucketAlreadyOwnedByYou(req.container_name)
+            raise BucketAlreadyExists(req.container_name)
+        try:
+            resp = super(UniqueBucketController, self).PUT(req)
+        except Exception:
+            # Container creation failed, remove reservation.
+            req.bucket_db.release(req.container_name)
+            raise
+
+        # Container creation succeeded, confirm reservation.
+        req.bucket_db.set_owner(req.container_name, req.account)
+        return resp
+
+    @public
+    def DELETE(self, req):
+        """
+        Handle DELETE Bucket request
+        """
+        # log_s3api_command(req, 'delete-bucket')
+        try:
+            resp = super(UniqueBucketController, self).DELETE(req)
+        except NoSuchBucket:
+            ct_owner = req.bucket_db.get_owner(req.container_name)
+            if ct_owner == req.account:
+                # The bucket used to be ours, but for some reason
+                # it has not been released.
+                req.bucket_db.release(req.container_name)
+            raise
+
+        if resp.is_success:
+            # Container deletion succeeded, reset owner.
+            req.bucket_db.release(req.container_name)
+
+        return resp

--- a/swift/common/middleware/s3api/s3request.py
+++ b/swift/common/middleware/s3api/s3request.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 OpenStack Foundation.
+# Copyright (c) 2014-2020 OpenStack Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ from swift.common.middleware.s3api.controllers import ServiceController, \
     LocationController, LoggingStatusController, PartController, \
     UploadController, UploadsController, VersioningController, \
     UnsupportedController, S3AclController, BucketController, \
-    TaggingController
+    TaggingController, UniqueBucketController
 from swift.common.middleware.s3api.s3response import AccessDenied, \
     InvalidArgument, InvalidDigest, BucketAlreadyOwnedByYou, \
     RequestTimeTooSkewed, S3Response, SignatureDoesNotMatch, \
@@ -531,14 +531,18 @@ class S3Request(swob.Request):
         self.bucket_in_host = self._parse_host()
         self.container_name, self.object_name = self._parse_uri()
         self._validate_headers()
-        # Lock in string-to-sign now, before we start messing with query params
-        self.string_to_sign = self._string_to_sign()
-        self.environ['s3api.auth_details'] = {
-            'access_key': self.access_key,
-            'signature': self.signature,
-            'string_to_sign': self.string_to_sign,
-            'check_signature': self.check_signature,
-        }
+        if not self._is_anonymous:
+            # Lock in string-to-sign now, before we start messing
+            # with query params
+            self.string_to_sign = self._string_to_sign()
+            self.environ['s3api.auth_details'] = {
+                'access_key': self.access_key,
+                'signature': self.signature,
+                'string_to_sign': self.string_to_sign,
+                'check_signature': self.check_signature,
+            }
+        else:
+            self.string_to_sign = None
         self.account = None
         self.user_id = None
         self.slo_enabled = slo_enabled
@@ -596,7 +600,15 @@ class S3Request(swob.Request):
 
     @property
     def _is_query_auth(self):
-        return 'AWSAccessKeyId' in self.params
+        return ('AWSAccessKeyId' in self.params or
+                'X-Amz-Credential' in self.params)
+
+    @property
+    def _is_anonymous(self):
+        return (not self._is_header_auth and
+                'Signature' not in self.params and
+                'Expires' not in self.params and
+                'X-Amz-Credential' not in self.params)
 
     def _parse_host(self):
         storage_domain = self.storage_domain
@@ -685,6 +697,10 @@ class S3Request(swob.Request):
         elif self._is_header_auth:
             self._validate_dates()
             return self._parse_header_authentication()
+        elif self.bucket_db and self._is_allowed_anonymous_request():
+            # This is an anonymous request, we will have to resolve the
+            # account name from the bucket name thanks to the bucket DB.
+            return None, None
         else:
             # if this request is neither query auth nor header auth
             # s3api regard this as not s3 request
@@ -715,6 +731,9 @@ class S3Request(swob.Request):
         :raises: AccessDenied
         :raises: RequestTimeTooSkewed
         """
+        if self._is_anonymous:
+            return
+
         date_header = self.headers.get('Date')
         amz_date_header = self.headers.get('X-Amz-Date')
         if not date_header and not amz_date_header:
@@ -1038,6 +1057,8 @@ class S3Request(swob.Request):
 
         if self.is_object_request:
             return ObjectController
+        elif self.bucket_db:
+            return UniqueBucketController
         return BucketController
 
     @property
@@ -1056,18 +1077,29 @@ class S3Request(swob.Request):
     def is_authenticated(self):
         return self.account is not None
 
+    @property
+    def bucket_db(self):
+        return self.environ.get('s3api.bucket_db')
+
     def to_swift_req(self, method, container, obj, query=None,
                      body=None, headers=None):
         """
         Create a Swift request based on this request's environment.
         """
-        if self.account is None:
-            account = self.access_key
-        else:
-            account = self.account
-
         env = self.environ.copy()
         env['swift.infocache'] = self.environ.setdefault('swift.infocache', {})
+
+        if container and self.bucket_db:
+            ct_owner = self.bucket_db.get_owner(container)
+            account = ct_owner if ct_owner else None
+        else:
+            account = None
+
+        if account is None:
+            if self.account is None:
+                account = self.access_key
+            else:
+                account = self.account
 
         def sanitize(value):
             if set(value).issubset(string.printable):
@@ -1198,6 +1230,12 @@ class S3Request(swob.Request):
                     HTTP_NO_CONTENT,
                 ],
             }
+            # If bucket creation succeeds after a timeout,
+            # we have to accept that the container already exists.
+            # We rely on the bucket_db to know if the bucket already
+            # exists or not.
+            if self.bucket_db:
+                code_map['PUT'].append(HTTP_NO_CONTENT)
         else:
             # Swift object access.
             code_map = {
@@ -1339,6 +1377,11 @@ class S3Request(swob.Request):
 
         sw_req = self.to_swift_req(method, container, obj, headers=headers,
                                    body=body, query=query)
+
+        if self.bucket_db:
+            if self._is_anonymous and method == 'HEAD':
+                # Allow anonymous HEAD requests to read object ACLs
+                sw_req.environ['swift.authorize_override'] = True
 
         try:
             sw_resp = sw_req.get_response(app)
@@ -1502,7 +1545,8 @@ class S3AclRequest(S3Request):
             env, app, slo_enabled, storage_domain, location, force_request_log,
             dns_compliant_bucket_names, allow_multipart_uploads)
         self.allow_no_owner = allow_no_owner
-        self.authenticate(app)
+        if not self._is_anonymous:
+            self.authenticate(app)
         self.acl_handler = None
 
     @property

--- a/swift/common/utils.py
+++ b/swift/common/utils.py
@@ -81,7 +81,7 @@ from six.moves.configparser import (ConfigParser, NoSectionError,
                                     NoOptionError, RawConfigParser)
 from six.moves import range, http_client
 from six.moves.urllib.parse import quote as _quote, unquote
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import parse_qs, urlparse
 
 from swift import gettext_ as _
 import swift.common.exceptions
@@ -6084,3 +6084,17 @@ class WatchdogTimeout(object):
 
     def __exit__(self, type, value, traceback):
         self.watchdog.stop(self.key)
+
+
+def parse_connection_string(conn_str):
+    """
+    Get the connection scheme, network host (or hosts)
+    and a dictionary of extra arguments from a connection string.
+
+    Example:
+    >>> parse_conn_str('redis://10.0.1.27:666,10.0.1.25:667?opt1=val1&opt2=5')
+    ('redis', '10.0.1.27:666,10.0.1.25:667', {'opt1': 'val1', 'opt2': '5'})
+    """
+    scheme, netloc, _, _, query, _ = urlparse(conn_str)
+    kwargs = {k: ','.join(v) for k, v in parse_qs(query).items()}
+    return scheme, netloc, kwargs

--- a/test/unit/common/middleware/s3api/test_bucket.py
+++ b/test/unit/common/middleware/s3api/test_bucket.py
@@ -1096,6 +1096,11 @@ class TestS3ApiBucket(S3ApiTestCase):
             code = self._test_method_error(
                 'PUT', '/bucket', swob.HTTPAccepted)
         self.assertEqual(code, 'BucketAlreadyExists')
+        if self.s3api.bucket_db:
+            self.s3api.bucket_db.reserve('bucket', 'AUTH_test')
+            code = self._test_method_error('PUT', '/bucket', swob.HTTPAccepted)
+            self.assertEqual(code, 'BucketAlreadyOwnedByYou')
+            self.s3api.bucket_db.release('bucket')
         code = self._test_method_error('PUT', '/bucket', swob.HTTPServerError)
         self.assertEqual(code, 'InternalError')
         code = self._test_method_error(

--- a/test/unit/common/middleware/s3api/test_bucket_db.py
+++ b/test/unit/common/middleware/s3api/test_bucket_db.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2020 OpenStack Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from swift.common import swob
+from swift.common.swob import Request
+from swift.common.utils import json
+from swift.common.middleware.s3api.bucket_db import get_bucket_db, \
+    BucketDbWrapper
+from swift.common.middleware.s3api.etree import fromstring
+from test.unit.common.middleware.s3api import S3ApiTestCase
+
+
+class TestSwift3BucketDb(S3ApiTestCase):
+
+    def __init__(self, name):
+        super(TestSwift3BucketDb, self).__init__(name)
+
+    def setUp(self):
+        super(TestSwift3BucketDb, self).setUp()
+        # Load dummy bucket DB (not using Redis)
+        self.s3api.conf.bucket_db_connection = 'dummy://'
+        self.s3api.bucket_db = get_bucket_db(self.s3api.conf)
+
+        self.swift.register('PUT', '/v1/AUTH_test2/bucket',
+                            swob.HTTPCreated, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_test2/bucket+segments',
+                            swob.HTTPNoContent, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_test/bucket-server-error',
+                            swob.HTTPServerError, {}, None)
+        self.swift.register(
+            'HEAD', '/v1/AUTH_test/bucket', swob.HTTPNoContent,
+            {'X-Container-Object-Count': 0}, None)
+        self.swift.register(
+            'GET', '/v1/AUTH_test/bucket', swob.HTTPOk,
+            {}, json.dumps([]))
+        self.swift.register(
+            'PUT', '/v1/AUTH_test/bucket+segments', swob.HTTPNoContent,
+            {}, None)
+        self.swift.register(
+            'GET', '/v1/AUTH_test/bucket+segments?format=json&marker=',
+            swob.HTTPNotFound, {}, None)
+        self.s3api.bucket_db = BucketDbWrapper(self.s3api.bucket_db)
+
+    @property
+    def db(self):
+        return self.s3api.bucket_db
+
+    def _bucket_op(self, op, bucket='bucket', account='test'):
+        req = Request.blank(
+            '/%s' % bucket,
+            environ={'REQUEST_METHOD': op},
+            headers={'Authorization': 'AWS %s:tester:hmac' % account,
+                     'Date': self.get_date_header()})
+        return self.call_s3api(req)
+
+    def _bucket_put(self, *args, **kwargs):
+        return self._bucket_op('PUT', *args, **kwargs)
+
+    def _bucket_get(self, *args, **kwargs):
+        return self._bucket_op('GET', *args, **kwargs)
+
+    def _bucket_delete(self, *args, **kwargs):
+        return self._bucket_op('DELETE', *args, **kwargs)
+
+    def test_bucket_PUT(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, headers, body = self._bucket_put()
+        self.assertEqual(body, b'')
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(headers['Location'], '/bucket')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+    def test_bucket_PUT_twice(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, headers, body = self._bucket_put()
+        self.assertEqual(body, b'')
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(headers['Location'], '/bucket')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+        status, headers, body = self._bucket_put()
+        self.assertEqual(status.split()[0], '409')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+    def test_bucket_PUT_other_account(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, headers, body = self._bucket_put()
+        self.assertEqual(body, b'')
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(headers['Location'], '/bucket')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+        status, headers, body = self._bucket_put(account='test2')
+        self.assertEqual(status.split()[0], '409')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+    def test_bucket_PUT_fail(self):
+        self.assertIsNone(self.db.get_owner('bucket-server-error'))
+        status, _, _ = self._bucket_put('bucket-server-error')
+        self.assertEqual(status.split()[0], '500')
+        self.assertIsNone(self.db.get_owner('bucket-server-error'))
+
+    def test_bucket_DELETE(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, body, _ = self._bucket_put()
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+        status, _, _ = self._bucket_delete()
+        self.assertEqual(status.split()[0], '204')
+        self.assertIsNone(self.db.get_owner('bucket'))
+
+    def test_bucket_DELETE_fail(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, _, _ = self._bucket_put()
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+        self.swift.register('DELETE', '/v1/AUTH_test/bucket',
+                            swob.HTTPServerError, {}, None)
+        status, _, _ = self._bucket_delete()
+        self.assertEqual(status.split()[0], '500')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+    def test_bucket_PUT_after_DELETE(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, _, _ = self._bucket_put()
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+        status, _, _ = self._bucket_delete()
+        self.assertEqual(status.split()[0], '204')
+        self.assertIsNone(self.db.get_owner('bucket'))
+
+        status, _, _ = self._bucket_put(account='test2')
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test2')
+
+    def test_bucket_GET_other_account(self):
+        self.assertIsNone(self.db.get_owner('bucket'))
+        status, _, _ = self._bucket_put()
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
+
+        # Register request with account 'test'.
+        expected_body = json.dumps(
+            [{"name": "expected",
+              "last_modified": "2017-04-21T16:30:34.133034",
+              "hash": "0000",
+              "bytes": 0}]).encode('utf-8')
+        self.swift.register('GET',
+                            '/v1/AUTH_test/bucket?limit=1001',
+                            swob.HTTPOk, {}, expected_body)
+        # Then do a call with 'test2' account, that should be changed
+        # to 'test' by the middleware (because the bucket 'bucket' belongs
+        # to account 'test').
+        status, _, body = self._bucket_get('bucket', account='test2')
+        elem = fromstring(body, "ListBucketResult")
+        self.assertEqual(status.split()[0], '200')
+        self.assertEqual(elem.find('Contents').find('Key').text, "expected")


### PR DESCRIPTION
A.K.A. the "bucket DB".

Besides making bucket names unique across the namespace, this database allows anonymous requests. Indeed the database is used to find which account the requested bucket belongs to, in order to check ACLs.

Note: this PR must be rebased and merged after #2.