### PR TITLE
Expose name of s3api command in swift.log_info

### DIFF
--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -577,6 +577,9 @@ use = egg:swift#s3api
 # upload, except the last part.
 # min_segment_size = 5242880
 
+# Expose S3API command in swift log
+# log_s3api_command = False
+
 # You can override the default log routing for this filter here:
 # log_name = s3api
 

--- a/etc/s3-default.cfg
+++ b/etc/s3-default.cfg
@@ -52,6 +52,7 @@ use = egg:swift#s3api
 location = RegionOne
 force_swift_request_proxy_log = true
 log_level = DEBUG
+log_s3api_command = True
 storage_domain = localhost
 s3_acl = true
 check_bucket_owner = true

--- a/swift/common/middleware/s3api/controllers/acl.py
+++ b/swift/common/middleware/s3api/controllers/acl.py
@@ -89,6 +89,11 @@ class AclController(Controller):
         """
         Handles GET Bucket acl and GET Object acl.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'get-object-acl')
+        else:
+            self.set_s3api_command(req, 'get-bucket-acl')
+
         resp = req.get_response(self.app, method='HEAD')
 
         return get_acl(req.user_id, resp.headers)
@@ -98,6 +103,11 @@ class AclController(Controller):
         """
         Handles PUT Bucket acl and PUT Object acl.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'put-object-acl')
+        else:
+            self.set_s3api_command(req, 'put-bucket-acl')
+
         if req.is_object_request:
             # Handle Object ACL
             raise S3NotImplemented()

--- a/swift/common/middleware/s3api/controllers/base.py
+++ b/swift/common/middleware/s3api/controllers/base.py
@@ -82,6 +82,7 @@ class Controller(object):
         self.app = app
         self.conf = conf
         self.logger = logger
+        self.command = None
 
     @classmethod
     def resource_type(cls):
@@ -90,6 +91,21 @@ class Controller(object):
         """
         name = cls.__name__[:-len('Controller')]
         return camel_to_snake(name).upper()
+
+    def set_s3api_command(self, req, command):
+        """
+        Set s3api command
+        and add this command to current request in swift.log_info fields.
+        :param req: HTTP request object
+        :param command: s3 command string
+        """
+        if self.command:
+            return
+        self.command = command
+        if not self.conf.log_s3api_command:
+            return
+        req.environ.setdefault(
+            'swift.log_info', list()).append(self.command)
 
 
 class UnsupportedController(Controller):

--- a/swift/common/middleware/s3api/controllers/bucket.py
+++ b/swift/common/middleware/s3api/controllers/bucket.py
@@ -93,6 +93,8 @@ class BucketController(Controller):
         """
         Handle HEAD Bucket (Get Metadata) request
         """
+        self.set_s3api_command(req, 'head-bucket')
+
         resp = req.get_response(self.app)
 
         return HTTPOk(headers=resp.headers)
@@ -302,6 +304,13 @@ class BucketController(Controller):
         encoding_type, query, listing_type, fetch_owner = \
             self._parse_request_options(req, max_keys)
 
+        if listing_type == 'object-versions':
+            self.set_s3api_command(req, 'list-object-versions')
+        elif listing_type == 'version-2':
+            self.set_s3api_command(req, 'list-objects-v2')
+        else:
+            self.set_s3api_command(req, 'list-objects')
+
         resp = req.get_response(self.app, query=query)
 
         objects = json.loads(resp.body)
@@ -331,6 +340,8 @@ class BucketController(Controller):
         """
         Handle PUT Bucket request
         """
+        self.set_s3api_command(req, 'create-bucket')
+
         xml = req.xml(MAX_PUT_BUCKET_BODY_SIZE)
         if xml:
             # check location
@@ -360,6 +371,8 @@ class BucketController(Controller):
         """
         Handle DELETE Bucket request
         """
+        self.set_s3api_command(req, 'delete-bucket')
+
         # NB: object_versioning is responsible for cleaning up its container
         if self.conf.allow_multipart_uploads:
             self._delete_segments_bucket(req)

--- a/swift/common/middleware/s3api/controllers/location.py
+++ b/swift/common/middleware/s3api/controllers/location.py
@@ -32,6 +32,8 @@ class LocationController(Controller):
         """
         Handles GET Bucket location.
         """
+        self.set_s3api_command(req, 'get-bucket-location')
+
         req.get_response(self.app, method='HEAD')
 
         elem = Element('LocationConstraint')

--- a/swift/common/middleware/s3api/controllers/logging.py
+++ b/swift/common/middleware/s3api/controllers/logging.py
@@ -37,6 +37,8 @@ class LoggingStatusController(Controller):
         """
         Handles GET Bucket logging.
         """
+        self.set_s3api_command(req, 'get-bucket-logging')
+
         req.get_response(self.app, method='HEAD')
 
         # logging disabled
@@ -51,4 +53,6 @@ class LoggingStatusController(Controller):
         """
         Handles PUT Bucket logging.
         """
+        self.set_s3api_command(req, 'put-bucket-logging')
+
         raise S3NotImplemented()

--- a/swift/common/middleware/s3api/controllers/multi_delete.py
+++ b/swift/common/middleware/s3api/controllers/multi_delete.py
@@ -50,6 +50,8 @@ class MultiObjectDeleteController(Controller):
         """
         Handles Delete Multiple Objects.
         """
+        self.set_s3api_command(req, 'delete-objects')
+
         def object_key_iter(elem):
             for obj in elem.iterchildren('Object'):
                 key = obj.find('./Key').text

--- a/swift/common/middleware/s3api/controllers/multi_upload.py
+++ b/swift/common/middleware/s3api/controllers/multi_upload.py
@@ -190,6 +190,11 @@ class PartController(Controller):
         """
         Handles Upload Part and Upload Part Copy.
         """
+        if 'X-Amz-Copy-Source' in req.headers and \
+                'X-Amz-Copy-Source-Range' in req.headers:
+            self.set_s3api_command(req, 'upload-part-copy')
+        else:
+            self.set_s3api_command(req, 'upload-part')
 
         if 'uploadId' not in req.params:
             raise InvalidArgument('ResourceType', 'partNumber',
@@ -258,6 +263,8 @@ class PartController(Controller):
         """
         Handles Get Part (regular Get but with ?part-number=N).
         """
+        self.set_s3api_command(req, 'get-object-part')
+
         return self.GETorHEAD(req)
 
     @public
@@ -267,6 +274,8 @@ class PartController(Controller):
         """
         Handles Head Part (regular HEAD but with ?part-number=N).
         """
+        self.set_s3api_command(req, 'head-object-part')
+
         return self.GETorHEAD(req)
 
     def GETorHEAD(self, req):
@@ -358,6 +367,7 @@ class UploadsController(Controller):
         """
         Handles List Multipart Uploads
         """
+        self.set_s3api_command(req, 'list-multipart-uploads')
 
         def separate_uploads(uploads, prefix, delimiter):
             """
@@ -506,6 +516,8 @@ class UploadsController(Controller):
         """
         Handles Initiate Multipart Upload.
         """
+        self.set_s3api_command(req, 'create-multipart-upload')
+
         # Create a unique S3 upload id from UUID to avoid duplicates.
         upload_id = unique_id()
 
@@ -570,6 +582,8 @@ class UploadController(Controller):
         """
         Handles List Parts.
         """
+        self.set_s3api_command(req, 'list-parts')
+
         def filter_part_num_marker(o):
             try:
                 num = int(os.path.basename(o['name']))
@@ -669,6 +683,8 @@ class UploadController(Controller):
         """
         Handles Abort Multipart Upload.
         """
+        self.set_s3api_command(req, 'abort-multipart-upload')
+
         upload_id = req.params['uploadId']
         _get_upload_info(req, self.app, upload_id)
 
@@ -712,6 +728,8 @@ class UploadController(Controller):
         """
         Handles Complete Multipart Upload.
         """
+        self.set_s3api_command(req, 'complete-multipart-upload')
+
         upload_id = req.params['uploadId']
         resp = _get_upload_info(req, self.app, upload_id)
         headers = {'Accept': 'application/json',

--- a/swift/common/middleware/s3api/controllers/obj.py
+++ b/swift/common/middleware/s3api/controllers/obj.py
@@ -133,6 +133,8 @@ class ObjectController(Controller):
         """
         Handle HEAD Object request
         """
+        self.set_s3api_command(req, 'head-object')
+
         resp = self.GETorHEAD(req)
 
         if 'range' in req.headers:
@@ -146,6 +148,8 @@ class ObjectController(Controller):
         """
         Handle GET Object request
         """
+        self.set_s3api_command(req, 'get-object')
+
         return self.GETorHEAD(req)
 
     @public
@@ -153,6 +157,11 @@ class ObjectController(Controller):
         """
         Handle PUT Object and PUT Object (Copy) request
         """
+        if 'X-Amz-Copy-Source' in req.headers:
+            self.set_s3api_command(req, 'copy-object')
+        else:
+            self.set_s3api_command(req, 'put-object')
+
         # set X-Timestamp by s3api to use at copy resp body
         req_timestamp = S3Timestamp.now()
         req.headers['X-Timestamp'] = req_timestamp.internal
@@ -220,6 +229,8 @@ class ObjectController(Controller):
         Handle DELETE Object request
         """
         version_id = version_id_param(req)
+        self.set_s3api_command(req, 'delete-object')
+
         if version_id not in ('null', None):
             container_info = req.get_container_info(self.app)
             if not container_info.get(

--- a/swift/common/middleware/s3api/controllers/s3_acl.py
+++ b/swift/common/middleware/s3api/controllers/s3_acl.py
@@ -36,6 +36,11 @@ class S3AclController(Controller):
         """
         Handles GET Bucket acl and GET Object acl.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'get-object-acl')
+        else:
+            self.set_s3api_command(req, 'get-bucket-acl')
+
         resp = req.get_response(self.app)
 
         acl = resp.object_acl if req.is_object_request else resp.bucket_acl
@@ -50,6 +55,11 @@ class S3AclController(Controller):
         """
         Handles PUT Bucket acl and PUT Object acl.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'put-object-acl')
+        else:
+            self.set_s3api_command(req, 'put-bucket-acl')
+
         # ACLs will be set as sysmeta
         req.get_response(self.app, 'POST')
 

--- a/swift/common/middleware/s3api/controllers/service.py
+++ b/swift/common/middleware/s3api/controllers/service.py
@@ -32,6 +32,8 @@ class ServiceController(Controller):
         """
         Handle GET Service request
         """
+        self.set_s3api_command(req, 'list-buckets')
+
         resp = req.get_response(self.app, query={'format': 'json'})
 
         containers = json.loads(resp.body)

--- a/swift/common/middleware/s3api/controllers/tagging.py
+++ b/swift/common/middleware/s3api/controllers/tagging.py
@@ -53,6 +53,11 @@ class TaggingController(Controller):
         """
         Handles GET Bucket and Object tagging.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'get-object-tagging')
+        else:
+            self.set_s3api_command(req, 'get-bucket-tagging')
+
         resp = req._get_response(self.app, 'HEAD',
                                  req.container_name, req.object_name)
         headers = dict()
@@ -82,6 +87,11 @@ class TaggingController(Controller):
         """
         Handles PUT Bucket and Object tagging.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'put-object-tagging')
+        else:
+            self.set_s3api_command(req, 'put-bucket-tagging')
+
         body = req.xml(MAX_TAGGING_BODY_SIZE)
         try:
             # Just validate the body
@@ -109,6 +119,11 @@ class TaggingController(Controller):
         """
         Handles DELETE Bucket and Object tagging.
         """
+        if req.is_object_request:
+            self.set_s3api_command(req, 'delete-object-tagging')
+        else:
+            self.set_s3api_command(req, 'delete-bucket-tagging')
+
         # Send empty header to remove any previous value.
         if req.object_name:
             req.headers[OBJECT_TAGGING_HEADER] = ""

--- a/swift/common/middleware/s3api/controllers/unique_bucket.py
+++ b/swift/common/middleware/s3api/controllers/unique_bucket.py
@@ -17,7 +17,6 @@ from swift.common.utils import public
 from swift.common.middleware.s3api.controllers import BucketController
 from swift.common.middleware.s3api.s3response import BucketAlreadyExists, \
     BucketAlreadyOwnedByYou, NoSuchBucket
-# from swift3.utils import log_s3api_command
 
 
 class UniqueBucketController(BucketController):
@@ -30,7 +29,8 @@ class UniqueBucketController(BucketController):
         """
         Handle PUT Bucket request
         """
-        # log_s3api_command(req, 'create-bucket')
+        self.set_s3api_command(req, 'create-bucket')
+
         # We are about to create a container, reserve its name.
         can_create = req.bucket_db.reserve(req.container_name, req.account)
         if not can_create:
@@ -54,7 +54,8 @@ class UniqueBucketController(BucketController):
         """
         Handle DELETE Bucket request
         """
-        # log_s3api_command(req, 'delete-bucket')
+        self.set_s3api_command(req, 'delete-bucket')
+
         try:
             resp = super(UniqueBucketController, self).DELETE(req)
         except NoSuchBucket:

--- a/swift/common/middleware/s3api/controllers/versioning.py
+++ b/swift/common/middleware/s3api/controllers/versioning.py
@@ -40,6 +40,8 @@ class VersioningController(Controller):
         """
         Handles GET Bucket versioning.
         """
+        self.set_s3api_command(req, 'get-bucket-versioning')
+
         sysmeta = req.get_container_info(self.app).get('sysmeta', {})
 
         elem = Element('VersioningConfiguration')
@@ -57,6 +59,8 @@ class VersioningController(Controller):
         """
         Handles PUT Bucket versioning.
         """
+        self.set_s3api_command(req, 'put-bucket-versioning')
+
         if 'object_versioning' not in get_swift_info():
             raise S3NotImplemented()
 

--- a/swift/common/middleware/s3api/s3api.py
+++ b/swift/common/middleware/s3api/s3api.py
@@ -277,6 +277,8 @@ class S3ApiMiddleware(object):
             conf.get('allow_multipart_uploads', True))
         self.conf.min_segment_size = config_positive_int_value(
             conf.get('min_segment_size', 5242880))
+        self.conf.log_s3api_command = config_true_value(
+            conf.get('log_s3api_command', False))
 
         self.logger = get_logger(
             conf, log_route=conf.get('log_name', 's3api'))

--- a/test/unit/common/middleware/s3api/__init__.py
+++ b/test/unit/common/middleware/s3api/__init__.py
@@ -86,6 +86,7 @@ class S3ApiTestCase(unittest.TestCase):
             'force_swift_request_proxy_log': False,
             'allow_multipart_uploads': True,
             'min_segment_size': 5242880,
+            'log_s3api_command': False
         })
         # those 2 settings has existed the original test setup
         self.conf.log_level = 'debug'


### PR DESCRIPTION
Each method will expose the s3api command in `swift.log_info` used by `proxy-logging` middleware: it is located just before `start_time` field