### PR TITLE
s3api: optimize multipart-upload operations

### DIFF
--- a/swift/common/middleware/s3api/acl_handlers.py
+++ b/swift/common/middleware/s3api/acl_handlers.py
@@ -421,7 +421,11 @@ class UploadAclHandler(MultiUploadAclHandler):
     def PUT(self, app):
         container = self.req.container_name + MULTIUPLOAD_SUFFIX
         obj = '%s/%s' % (self.obj, self.req.params['uploadId'])
-        resp = self.req._get_response(app, 'HEAD', container, obj)
+        self.req.environ['oio.ephemeral_object'] = True
+        try:
+            resp = self.req._get_response(app, 'HEAD', container, obj)
+        finally:
+            self.req.environ['oio.ephemeral_object'] = False
         self.req.headers[sysmeta_header('object', 'acl')] = \
             resp.sysmeta_headers.get(sysmeta_header('object', 'tmpacl'))
 

--- a/swift/common/middleware/s3api/controllers/multi_upload.py
+++ b/swift/common/middleware/s3api/controllers/multi_upload.py
@@ -545,7 +545,7 @@ class UploadsController(Controller):
 
         result_elem = Element('InitiateMultipartUploadResult')
         SubElement(result_elem, 'Bucket').text = req.container_name
-        SubElement(result_elem, 'Key').text = req.object_name
+        SubElement(result_elem, 'Key').text = wsgi_to_str(req.object_name)
         SubElement(result_elem, 'UploadId').text = upload_id
 
         body = tostring(result_elem)

--- a/swift/common/middleware/s3api/controllers/multi_upload.py
+++ b/swift/common/middleware/s3api/controllers/multi_upload.py
@@ -108,6 +108,7 @@ def _get_upload_info(req, app, upload_id):
     # for the upload marker. Until we get around to fixing that, just pop
     # it off for now...
     copy_source = req.headers.pop('X-Amz-Copy-Source', None)
+    req.environ['oio.ephemeral_object'] = True
     try:
         return req.get_response(app, 'HEAD', container=container, obj=obj)
     except NoSuchKey:
@@ -123,6 +124,7 @@ def _get_upload_info(req, app, upload_id):
         # ...making sure to restore any copy-source before returning
         if copy_source is not None:
             req.headers['X-Amz-Copy-Source'] = copy_source
+        req.environ['oio.ephemeral_object'] = False
 
 
 def _make_complete_body(req, s3_etag, yielded_anything):
@@ -418,6 +420,7 @@ class UploadsController(Controller):
 
         container = req.container_name + MULTIUPLOAD_SUFFIX
         try:
+            req.environ['oio.list_mpu'] = True
             resp = req.get_response(self.app, container=container, query=query)
             objects = json.loads(resp.body)
         except NoSuchBucket:
@@ -540,6 +543,7 @@ class UploadsController(Controller):
 
         req.headers.pop('Etag', None)
         req.headers.pop('Content-Md5', None)
+        req.environ['oio.ephemeral_object'] = True
 
         req.get_response(self.app, 'PUT', seg_container, obj, body='')
 
@@ -677,7 +681,9 @@ class UploadController(Controller):
         # then it was completed and we return an error here.
         container = req.container_name + MULTIUPLOAD_SUFFIX
         obj = '%s/%s' % (req.object_name, upload_id)
+        req.environ['oio.ephemeral_object'] = True
         req.get_response(self.app, container=container, obj=obj)
+        req.environ['oio.ephemeral_object'] = False
 
         # The completed object was not found so this
         # must be a multipart upload abort.
@@ -870,6 +876,7 @@ class UploadController(Controller):
 
                 # clean up the multipart-upload record
                 obj = '%s/%s' % (req.object_name, upload_id)
+                req.environ['oio.ephemeral_object'] = True
                 try:
                     req.get_response(self.app, 'DELETE', container, obj)
                 except NoSuchKey:


### PR DESCRIPTION
This PR will:
- fix response of `create-multipart-upload` for non-ascii key
- tag subrequest issued by MPU controllers (`oio.ephemeral_object` and `oio.list_mpu`) to be handled by a dedicated middleware 