### PR TITLE
Check IAM rules before handling requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 env:
   matrix:
-#    - TEST_SUITE=iam
+    - TEST_SUITE=iam SDS_BRANCH=master
 #    - TEST_SUITE=s3 # Latest stable/supported versions
     - TEST_SUITE=s3 SDS_BRANCH=master # Integration with latest versions
     - TEST_SUITE=s3-basic SDS_BRANCH=master # Integration with latest versions

--- a/etc/iam-rules-sample.json
+++ b/etc/iam-rules-sample.json
@@ -1,0 +1,132 @@
+{
+    "demo:demo": {
+        "Statement": [
+            {
+                "Sid": "FullAccess",
+                "Action": [
+                    "s3:*"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    },
+    "demo:user1": {
+        "Statement": [
+            {
+                "Sid": "User1BucketAllObjects",
+                "Action": [
+                    "s3:ListBucket",
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "arn:aws:s3:::user1bucket",
+                    "arn:aws:s3:::user1bucket/*"
+                ]
+            },
+            {
+                "Sid": "SharedBucketUser1Objects",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "arn:aws:s3:::sharedbucket/user1_*"
+                ]
+            },
+            {
+                "Sid": "SharedBucketAllObjects",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "arn:aws:s3:::sharedbucket",
+                    "arn:aws:s3:::sharedbucket/*"
+                ]
+            },
+            {
+                "Sid": "NavToUserFolder",
+                "Action": ["s3:ListBucket"],
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::companybucket"],
+                "Condition": {"StringEquals":{"s3:prefix":["", "home/", "home/user1/"]}}
+            },
+            {
+                "Sid": "UserFolder",
+                "Action": ["s3:ListBucket"],
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::companybucket"],
+                "Condition": {"StringLike":{"s3:prefix":["home/user1/*"]}}
+            },
+            {
+                "Sid": "UserFolderObjects",
+                "Action": ["s3:*"],
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::companybucket/home/user1/*"]
+            }
+        ]
+    },
+    "demo:user2": {
+        "Statement": [
+            {
+                "Sid": "NavToUserFolder",
+                "Action": ["s3:ListBucket"],
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::companybucket"],
+                "Condition": {"StringEquals":{"s3:prefix":["", "home/", "home/user2/"]}}
+            },
+            {
+                "Sid": "UserFolder",
+                "Action": ["s3:ListBucket"],
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::companybucket"],
+                "Condition": {"StringLike":{"s3:prefix":["home/user2/*"]}}
+            },
+            {
+                "Sid": "UserFolderObjects",
+                "Action": ["s3:*"],
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::companybucket/home/user2/*"]
+            }
+        ]
+    },
+    "account2:admin": {
+        "Statement": [
+            {
+                "Sid": "FullAccess",
+                "Action": [
+                    "s3:*"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    },
+    "account2:user1": {
+        "Statement": [
+            {
+                "Sid": "SharedBucketAllObjects",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "arn:aws:s3:::sharedbucket",
+                    "arn:aws:s3:::sharedbucket/*"
+                ]
+            }
+        ]
+    }
+}

--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -481,6 +481,38 @@ user_test5_tester5 = testing5 service
 # in ACLs by setting allow_names_in_acls to false:
 # allow_names_in_acls = true
 
+# Note: put iam before s3api in the pipeline.
+# If you don't put it in the pipeline, it will be disabled.
+[filter:iam]
+use = egg:swift#iam
+
+# Load IAM user policies from a JSON file.
+# The file must contain a JSON object, with one IAM policy document per
+# user ID. Example for tempauth user "admin" from account "admin":
+#
+# {
+#   "admin:admin": {
+#     "Statement": [
+#       {
+#         "Sid": "FullAccess",
+#         "Action": [
+#           "s3:*"
+#         ],
+#         "Effect": "Allow",
+#         "Resource": [
+#           "*"
+#         ]
+#       }
+#     ]
+#   }
+# }
+connection = file:///etc/swift/iam_rules.json
+
+# Keep this number of rules in cache
+cache_size = 1000
+# Keep rules in cache for this long (seconds)
+cache_ttl = 30
+
 [filter:s3api]
 use = egg:swift#s3api
 

--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -481,12 +481,13 @@ user_test5_tester5 = testing5 service
 # in ACLs by setting allow_names_in_acls to false:
 # allow_names_in_acls = true
 
-# Note: put iam before s3api in the pipeline.
+# Note: put iam before authtoken and s3api in the pipeline.
 # If you don't put it in the pipeline, it will be disabled.
 [filter:iam]
-use = egg:swift#iam
+use = egg:swift#oioiam
 
-# Load IAM user policies from a JSON file.
+# Load IAM user policies from a JSON file or from a Redis database.
+#
 # The file must contain a JSON object, with one IAM policy document per
 # user ID. Example for tempauth user "admin" from account "admin":
 #
@@ -506,12 +507,48 @@ use = egg:swift#iam
 #     ]
 #   }
 # }
-connection = file:///etc/swift/iam_rules.json
+#
+# When using a Redis database, the rules can be manipulated with the
+# following commands:
+# - openio-admin iam set-user-policy
+# - openio-admin iam get-user-policy
+#
+# A good user policy example is documented here
+# https://aws.amazon.com/blogs/security/writing-iam-policies-grant-access-to-user-specific-folders-in-an-amazon-s3-bucket/
+
+# When running with an OpenIO backend, the 'connection' parameter can also
+# be set in the namespace's configuration file, under the key 'iam.connection'.
+
+# Load IAM user policies from a JSON file.
+#connection = file:///etc/swift/iam_rules.json
+
+# Load IAM user policies from a Redis database.
+#connection = redis://127.0.0.1:6379
+
+# Load IAM user policies from a Redis database, with Redis Sentinel enabled.
+connection = redis+sentinel://10.0.1.24:6012,10.0.1.27:6012,10.0.1.25:6012?sentinel_name=IAM-master-1
+
+# Required parameters when using Redis Sentinel:
+# - sentinel_name
+
+# Available connection parameters:
+# - socket_timeout
+# - socket_connect_timeout
+# - socket_keepalive
+# - retry_on_timeout
+# - max_connections
+# - sentinel_socket_timeout
+# - sentinel_socket_connect_timeout
+# - sentinel_socket_keepalive
+# - sentinel_retry_on_timeout
+# - sentinel_max_connections
+# - key_prefix ("IAM:" by default)
 
 # Keep this number of rules in cache
-cache_size = 1000
+#cache_size = 1000
+
 # Keep rules in cache for this long (seconds)
-cache_ttl = 30
+#cache_ttl = 30
 
 [filter:s3api]
 use = egg:swift#s3api
@@ -1009,7 +1046,7 @@ use = egg:swift#proxy_logging
 # log_anonymization_method = MD5
 #
 # Salt added during log anonymization
-# log_anonymization_salt = 
+# log_anonymization_salt =
 #
 # Template used to format access logs. All words surrounded by curly brackets
 # will be substituted with the appropriate values

--- a/etc/s3-iam.cfg.in
+++ b/etc/s3-iam.cfg.in
@@ -1,0 +1,94 @@
+[DEFAULT]
+bind_port = 5000
+workers = 1
+user = %USER%
+log_facility = LOG_LOCAL0
+log_level = DEBUG
+eventlet_debug = true
+sds_default_account = AUTH_demo
+
+[pipeline:main]
+pipeline = catch_errors proxy-logging cache iam s3api tempauth proxy-logging copy slo versioned_writes symlink proxy-server
+
+[app:proxy-server]
+use = egg:swift#oio_proxy
+allow_account_management = true
+account_autocreate = true
+sds_namespace = OPENIO
+sds_proxy_url = http://127.0.0.1:6000
+log_name = OIO,NS,oioswift,1
+sds_connection_timeout=5
+sds_read_timeout=20
+sds_write_timeout=20
+delete_slo_parts=true
+
+[filter:gatekeeper]
+use = egg:swift#gatekeeper
+
+[filter:proxy-logging]
+use = egg:swift#proxy_logging
+
+[filter:catch_errors]
+use = egg:swift#catch_errors
+
+[filter:ratelimit]
+use = egg:swift#ratelimit
+
+[filter:healthcheck]
+use = egg:swift#healthcheck
+
+[filter:cache]
+use = egg:swift#memcache
+memcache_servers = 127.0.0.1:11211
+
+[filter:slo]
+use = egg:swift#slo
+
+[filter:staticweb]
+use = egg:swift#staticweb
+
+[filter:iam]
+use = egg:swift#iam
+log_level = DEBUG
+connection = file://%RULES_FILE%
+
+[filter:s3api]
+use = egg:swift#s3api
+location = RegionOne
+force_swift_request_proxy_log = true
+log_level = DEBUG
+storage_domain = localhost
+s3_acl = true
+check_bucket_owner = true
+# min_segment_size = 8
+bucket_db_connection = redis://127.0.0.1:6379
+
+[filter:tempauth]
+use = egg:swift#tempauth
+log_level = DEBUG
+# Main user of the account AUTH_demo
+user_demo_demo = DEMO_PASS .admin
+# Unpriviledged user of the account AUTH_demo
+user_demo_user1 = USER_PASS
+
+# Main user of the account AUTH_account2
+user_account2_admin = ADMIN_PASS .admin
+# Unpriviledged user of the account AUTH_account2
+user_account2_user1 = USER_PASS
+
+[filter:versioned_writes]
+use = egg:swift#versioned_writes
+allow_versioned_writes = true
+allow_object_versioning = true
+allow_oio_versioning = true
+
+[filter:copy]
+use = egg:swift#copy
+
+[filter:symlink]
+use = egg:swift#symlink
+# Symlinks can point to other symlinks provided the number of symlinks in a
+# chain does not exceed the symloop_max value. If the number of chained
+# symlinks exceeds the limit symloop_max a 409 (HTTPConflict) error
+# response will be produced.
+# symloop_max = 2

--- a/etc/s3-iam.cfg.in
+++ b/etc/s3-iam.cfg.in
@@ -48,9 +48,9 @@ use = egg:swift#slo
 use = egg:swift#staticweb
 
 [filter:iam]
-use = egg:swift#iam
+use = egg:swift#oioiam
 log_level = DEBUG
-connection = file://%RULES_FILE%
+connection = %IAM_RULES_CONN%
 
 [filter:s3api]
 use = egg:swift#s3api

--- a/oio_tests/functional/run-iam-tests.sh
+++ b/oio_tests/functional/run-iam-tests.sh
@@ -10,9 +10,21 @@ run_sds || exit 1
 configure_aws
 configure_s3cmd
 
-# IAM
+# IAM, with static file
 RULES_FILE="$PWD/etc/iam-rules-sample.json"
-sed -e "s#%RULES_FILE%#${RULES_FILE}#g" etc/s3-iam.cfg.in > etc/s3-iam.cfg
+sed -e "s#%IAM_RULES_CONN%#file://${RULES_FILE}#g" etc/s3-iam.cfg.in > etc/s3-iam.cfg
+run_functional_test s3-iam.cfg s3-iam.sh
+
+# IAM, with rules in a Redis database
+CONN_STR="redis://127.0.0.1:6379"
+for USER in $(jq -r --raw-output 'keys | .[]' $RULES_FILE)
+do
+  RULE="$(jq -c ".\"$USER\"" $RULES_FILE)"
+  ACCOUNT="AUTH_$(echo "$USER" | cut -d ':' -f 1)"
+  openio-admin iam set-user-policy --connection "$CONN_STR" "$ACCOUNT" "$USER" "$RULE"
+done
+
+sed -e "s#%IAM_RULES_CONN%#${CONN_STR}#g" etc/s3-iam.cfg.in > etc/s3-iam.cfg
 run_functional_test s3-iam.cfg s3-iam.sh
 
 # TODO(FVE): gridinit_cmd stop

--- a/oio_tests/functional/run-iam-tests.sh
+++ b/oio_tests/functional/run-iam-tests.sh
@@ -11,8 +11,8 @@ configure_aws
 configure_s3cmd
 
 # IAM
-RULES_FILE="$PWD/conf/iam_rules.json"
-sed -e "s#%RULES_FILE%#${RULES_FILE}#g" conf/s3-iam.cfg.in > conf/s3-iam.cfg
+RULES_FILE="$PWD/etc/iam-rules-sample.json"
+sed -e "s#%RULES_FILE%#${RULES_FILE}#g" etc/s3-iam.cfg.in > etc/s3-iam.cfg
 run_functional_test s3-iam.cfg s3-iam.sh
 
 # TODO(FVE): gridinit_cmd stop

--- a/oio_tests/functional/s3-iam.sh
+++ b/oio_tests/functional/s3-iam.sh
@@ -44,6 +44,9 @@ test_create_objects() {
   ${AWSA1ADM} s3 cp /etc/magic s3://${SHARED_BUCKET}/magic
   ${AWSA1ADM} s3 cp "${BIGFILE}" s3://${SHARED_BUCKET}/bigfiles/bigfile
 
+  # Create an object to test public-read access later
+  ${AWSA1ADM} s3 cp --acl public-read /etc/magic s3://${SHARED_BUCKET}/public-magic
+
   # user1 can create any object in its own bucket
   ${AWSA1U1} s3 cp /etc/magic s3://${U1_BUCKET}/magic
   ${AWSA1U1} s3 cp /etc/magic s3://${U1_BUCKET}/not_so_magic
@@ -112,6 +115,9 @@ test_read_objects() {
   # admin can read objects from any bucket
   ${AWSA1ADM} s3 cp s3://${U1_BUCKET}/magic "$TEMPDIR/magic"
   ${AWSA1ADM} s3 cp s3://${U1_BUCKET}/bigfiles/bigfile "$TEMPDIR/bigfile_from_u1_bucket"
+
+  # Anonymous users can read "public-read" objects
+  curl -I "http://localhost:5000/${SHARED_BUCKET}/public-magic"
 }
 
 test_delete_objects() {
@@ -130,6 +136,7 @@ test_delete_objects() {
 
   # admin can delete objects from any bucket
   ${AWSA1ADM} s3 rm s3://${SHARED_BUCKET}/magic
+  ${AWSA1ADM} s3 rm s3://${SHARED_BUCKET}/public-magic
   ${AWSA1ADM} s3 rm s3://${SHARED_BUCKET}/user1_bigfile
   ${AWSA1ADM} s3 rm s3://${SHARED_BUCKET}/bigfiles/bigfile
   ${AWSA1ADM} s3 rm s3://${U1_BUCKET}/not_so_magic

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,6 +129,7 @@ paste.filter_factory =
     s3api = swift.common.middleware.s3api.s3api:filter_factory
     s3token = swift.common.middleware.s3api.s3token:filter_factory
     etag_quoter = swift.common.middleware.etag_quoter:filter_factory
+    iam = swift.common.middleware.s3api.iam:filter_factory
 
 swift.diskfile =
     replication.fs = swift.obj.diskfile:DiskFileManager

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,10 +130,15 @@ paste.filter_factory =
     s3token = swift.common.middleware.s3api.s3token:filter_factory
     etag_quoter = swift.common.middleware.etag_quoter:filter_factory
     iam = swift.common.middleware.s3api.iam:filter_factory
+    oioiam = swift.common.middleware.s3api.oioiam:filter_factory
 
 swift.diskfile =
     replication.fs = swift.obj.diskfile:DiskFileManager
     erasure_coding.fs = swift.obj.diskfile:ECDiskFileManager
+
+openio.admin =
+    iam_get-user-policy = swift.common.middleware.s3api.oioiam:IamGetUserPolicy
+    iam_set-user-policy = swift.common.middleware.s3api.oioiam:IamSetUserPolicy
 
 [egg_info]
 tag_build =

--- a/swift/common/middleware/s3api/acl_utils.py
+++ b/swift/common/middleware/s3api/acl_utils.py
@@ -20,6 +20,9 @@ from swift.common.middleware.s3api.s3response import S3NotImplemented, \
     MalformedACLError, InvalidArgument
 
 
+ACL_EXPLICIT_ALLOW = 'swift.acl.explicit_allow'
+
+
 def swift_acl_translate(acl, group='', user='', xml=False):
     """
     Takes an S3 style ACL and returns a list of header/value pairs that

--- a/swift/common/middleware/s3api/controllers/bucket.py
+++ b/swift/common/middleware/s3api/controllers/bucket.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2014 OpenStack Foundation.
+# Copyright (c) 2010-2020 OpenStack Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ from swift.common.utils import json, public, config_true_value, Timestamp, \
 from swift.common.middleware.s3api.controllers.base import Controller
 from swift.common.middleware.s3api.etree import Element, SubElement, \
     tostring, fromstring, XMLSyntaxError, DocumentInvalid
+from swift.common.middleware.s3api.iam import check_iam_access
 from swift.common.middleware.s3api.s3response import \
     HTTPOk, S3NotImplemented, InvalidArgument, \
     MalformedXML, InvalidLocationConstraint, NoSuchBucket, \
@@ -89,6 +90,7 @@ class BucketController(Controller):
             raise ServiceUnavailable()
 
     @public
+    @check_iam_access("s3:ListBucket")
     def HEAD(self, req):
         """
         Handle HEAD Bucket (Get Metadata) request
@@ -291,6 +293,7 @@ class BucketController(Controller):
                                  fetch_owner)
 
     @public
+    @check_iam_access("s3:ListBucket")
     def GET(self, req):
         """
         Handle GET Bucket (List Objects) request
@@ -311,6 +314,7 @@ class BucketController(Controller):
         else:
             self.set_s3api_command(req, 'list-objects')
 
+        query['format'] = 'json'
         resp = req.get_response(self.app, query=query)
 
         objects = json.loads(resp.body)
@@ -336,6 +340,7 @@ class BucketController(Controller):
         return HTTPOk(body=body, content_type='application/xml')
 
     @public
+    @check_iam_access("s3:CreateBucket")
     def PUT(self, req):
         """
         Handle PUT Bucket request
@@ -367,6 +372,7 @@ class BucketController(Controller):
         return resp
 
     @public
+    @check_iam_access("s3:DeleteBucket")
     def DELETE(self, req):
         """
         Handle DELETE Bucket request

--- a/swift/common/middleware/s3api/controllers/location.py
+++ b/swift/common/middleware/s3api/controllers/location.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2014 OpenStack Foundation.
+# Copyright (c) 2010-2020 OpenStack Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ from swift.common.utils import public
 from swift.common.middleware.s3api.controllers.base import Controller, \
     bucket_operation
 from swift.common.middleware.s3api.etree import Element, tostring
+from swift.common.middleware.s3api.iam import check_iam_access
 from swift.common.middleware.s3api.s3response import HTTPOk
 
 
@@ -28,6 +29,7 @@ class LocationController(Controller):
     """
     @public
     @bucket_operation
+    @check_iam_access('s3:GetBucketLocation')
     def GET(self, req):
         """
         Handles GET Bucket location.

--- a/swift/common/middleware/s3api/controllers/multi_upload.py
+++ b/swift/common/middleware/s3api/controllers/multi_upload.py
@@ -88,6 +88,7 @@ from swift.common.middleware.s3api.s3response import InvalidArgument, \
     InvalidRequest, HTTPOk, HTTPNoContent, NoSuchKey, NoSuchUpload, \
     NoSuchBucket, BucketAlreadyOwnedByYou, InvalidRange
 from swift.common.middleware.s3api.exception import BadSwiftRequest
+from swift.common.middleware.s3api.iam import check_iam_access
 from swift.common.middleware.s3api.utils import unique_id, \
     MULTIUPLOAD_SUFFIX, S3Timestamp, sysmeta_header
 from swift.common.middleware.s3api.etree import Element, SubElement, \
@@ -190,6 +191,7 @@ class PartController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access('s3:PutObject')
     def PUT(self, req):
         """
         Handles Upload Part and Upload Part Copy.
@@ -263,6 +265,7 @@ class PartController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access("s3:GetObject")
     def GET(self, req):
         """
         Handles Get Part (regular Get but with ?part-number=N).
@@ -274,6 +277,7 @@ class PartController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access("s3:GetObject")
     def HEAD(self, req):
         """
         Handles Head Part (regular HEAD but with ?part-number=N).
@@ -367,6 +371,7 @@ class UploadsController(Controller):
                       err_msg="Key is not expected for the GET method "
                               "?uploads subresource")
     @check_container_existence
+    @check_iam_access('s3:ListBucketMultipartUploads')
     def GET(self, req):
         """
         Handles List Multipart Uploads
@@ -517,6 +522,7 @@ class UploadsController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access('s3:PutObject')
     def POST(self, req):
         """
         Handles Initiate Multipart Upload.
@@ -589,6 +595,7 @@ class UploadController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access('s3:ListMultipartUploadParts')
     def GET(self, req):
         """
         Handles List Parts.
@@ -690,6 +697,7 @@ class UploadController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access('s3:AbortMultipartUpload')
     def DELETE(self, req):
         """
         Handles Abort Multipart Upload.
@@ -737,6 +745,7 @@ class UploadController(Controller):
     @public
     @object_operation
     @check_container_existence
+    @check_iam_access('s3:PutObject')
     def POST(self, req):
         """
         Handles Complete Multipart Upload.

--- a/swift/common/middleware/s3api/controllers/obj.py
+++ b/swift/common/middleware/s3api/controllers/obj.py
@@ -28,6 +28,7 @@ from swift.common.middleware.s3api.utils import S3Timestamp, sysmeta_header
 from swift.common.middleware.s3api.controllers.base import Controller
 from swift.common.middleware.s3api.controllers.tagging import \
     HTTP_HEADER_TAGGING_KEY, OBJECT_TAGGING_HEADER, tagging_header_to_xml
+from swift.common.middleware.s3api.iam import check_iam_access
 from swift.common.middleware.s3api.s3response import S3NotImplemented, \
     InvalidRange, NoSuchKey, NoSuchVersion, InvalidArgument, HTTPNoContent, \
     PreconditionFailed
@@ -131,6 +132,7 @@ class ObjectController(Controller):
         return resp
 
     @public
+    @check_iam_access("s3:GetObject")
     def HEAD(self, req):
         """
         Handle HEAD Object request
@@ -146,6 +148,7 @@ class ObjectController(Controller):
         return resp
 
     @public
+    @check_iam_access("s3:GetObject")
     def GET(self, req):
         """
         Handle GET Object request
@@ -155,6 +158,7 @@ class ObjectController(Controller):
         return self.GETorHEAD(req)
 
     @public
+    @check_iam_access("s3:PutObject")
     def PUT(self, req):
         """
         Handle PUT Object and PUT Object (Copy) request
@@ -232,6 +236,7 @@ class ObjectController(Controller):
             container_info.get('sysmeta', {}).get('versions-enabled', False))
 
     @public
+    @check_iam_access("s3:DeleteObject")
     def DELETE(self, req):
         """
         Handle DELETE Object request

--- a/swift/common/middleware/s3api/exception.py
+++ b/swift/common/middleware/s3api/exception.py
@@ -34,3 +34,7 @@ class InvalidSubresource(S3Exception):
     def __init__(self, resource, cause):
         self.resource = resource
         self.cause = cause
+
+
+class IAMException(S3Exception):
+    pass

--- a/swift/common/middleware/s3api/iam.py
+++ b/swift/common/middleware/s3api/iam.py
@@ -1,0 +1,484 @@
+# Copyright (c) 2020 OpenStack Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fnmatch import fnmatchcase
+from functools import wraps
+
+from swift.common.middleware.s3api.acl_utils import ACL_EXPLICIT_ALLOW
+from swift.common.middleware.s3api.exception import IAMException
+from swift.common.middleware.s3api.s3response import AccessDenied
+from swift.common.utils import config_auto_int_value, get_logger, LRUCache
+
+
+ARN_AWS_PREFIX = "arn:aws:"
+ARN_S3_PREFIX = ARN_AWS_PREFIX + "s3:::"
+
+# Match every bucket
+ARN_WILDCARD_BUCKET = ARN_S3_PREFIX + "*"
+
+ACTION_WILDCARD = "s3:*"
+EXPLICIT_ALLOW = "ALLOW"
+EXPLICIT_DENY = "DENY"
+RESOURCE_VERSION = "2012-10-17"
+
+# Rule effect: allow
+RE_ALLOW = "Allow"
+# Rule effect: deny
+RE_DENY = "Deny"
+
+# Resource type: object
+RT_OBJECT = "Object"
+# Resource type: bucket
+RT_BUCKET = "Bucket"
+
+SUPPORTED_ACTIONS = {
+    "s3:AbortMultipartUpload": RT_OBJECT,
+    "s3:CreateBucket": RT_BUCKET,
+    "s3:DeleteBucket": RT_BUCKET,
+    "s3:DeleteObject": RT_OBJECT,
+    "s3:GetBucketLocation": RT_BUCKET,
+    "s3:ListBucket": RT_BUCKET,
+    "s3:ListMultipartUploadParts": RT_OBJECT,
+    "s3:ListBucketMultipartUploads": RT_BUCKET,
+    "s3:PutObject": RT_OBJECT,
+    "s3:GetObject": RT_OBJECT
+}
+
+IAM_EXPLICIT_ALLOW = 'swift.iam.explicit_allow'
+IAM_RULES_CALLBACK = 'swift.callback.fetch_iam_rules'
+
+
+class IamResource(object):
+    """
+    Represents a resource in the sense intended in the IAM specification.
+    """
+
+    def __init__(self, name):
+        if name.startswith(ARN_AWS_PREFIX):
+            self._resource_name = name
+        else:
+            self._resource_name = ARN_S3_PREFIX + name
+
+    @property
+    def arn(self):
+        return self._resource_name
+
+    def is_bucket(self):
+        return '/' not in self._resource_name
+
+    def is_object(self):
+        return '/' in self._resource_name
+
+    @property
+    def type(self):
+        return RT_BUCKET if self.is_bucket() else RT_OBJECT
+
+
+def string_equals(actual, expected):
+    """
+    Check if `actual` is equal to one of the strings in the `expected` list.
+
+    :type expected: list
+    :type actual: str
+    :rtype: bool
+    :returns: True if actual is in the list of expected strings
+    """
+    return actual in expected
+
+
+def string_like(actual, expected):
+    """
+    Try to match `actual` to one of the patterns in `expected`.
+
+    :returns: True if `actual` matches one of the patterns in `expected`
+    """
+    if actual is None:
+        return False
+    for pattern in expected:
+        if fnmatchcase(actual, pattern):
+            return True
+    return False
+
+
+# See iam-ug.pdf document, page 569.
+IamConditionOp = {
+    "StringEquals": string_equals,
+    "StringNotEquals": lambda a, e: not string_equals(a, e),
+    "StringLike": string_like,
+    "StringNotLike": lambda a, e: not string_like(a, e),
+    # TODO(IAM): implement the following functions
+    "IpAddress": None,
+    "NotIpAddress": None,
+    "StringEqualsIgnoreCase": None,
+    "StringNotEqualsIgnoreCase": None,
+}
+
+
+# See iam-ug.pdf document, page 629.
+IamConditionKey = {
+    "s3:delimiter": lambda req: req.params.get('delimiter'),
+    "s3:max-keys": lambda req: req.params.get('max-keys'),
+    "s3:prefix": lambda req: req.params.get('prefix'),
+    # TODO(IAM): implement the following keys
+    "aws:CurrentTime": None,
+    "aws:EpochTime": None,
+    "aws:SourceIp": None,
+    "aws:UserAgent": None,
+    "aws:userid": None,
+    "s3:VersionId": None,
+    "s3:x-amz-acl": None,
+    "s3:x-amz-copy-source": None,
+    "s3:x-amz-metadata-directive": None,
+    # referer (bucket policy)
+    # custom header with specific value
+}
+
+
+# TODO(IAM): merge this class into StaticIamMiddleware
+# so we can make subrequests to load resource-based policies.
+class IamRulesMatcher(object):
+    """
+    Matches an action and a resource against a set of IAM rules.
+
+    Only S3 actions are supported at the moment.
+    """
+
+    def __init__(self, rules, logger=None):
+        self._rules = rules
+        self.logger = logger or get_logger(None, log_route='iam')
+
+    def __call__(self, resource, action, req=None):
+        """
+        Match the specified action and resource against the set of IAM rules.
+
+        :param action: the S3 action to match.
+        :type action: `str`
+        :param resource: the resource to match.
+        :type resource: `Resource`
+        :param req: the S3 request object
+        """
+        if action not in SUPPORTED_ACTIONS:
+            raise IAMException("Unsupported action: %s" % action)
+
+        if resource.type != SUPPORTED_ACTIONS[action]:
+            raise IAMException(
+                "Action %s does not apply on %s resources" %
+                (action, resource.type))
+
+        # Start by matching explicit denies, because they take precedence
+        # over explicit allows.
+        matched, rule_name = self.match_explicit_deny(action, resource, req)
+        if matched:
+            return EXPLICIT_DENY, rule_name
+        # Then match explicit allows.
+        matched, rule_name = self.match_explicit_allow(action, resource, req)
+        if matched:
+            return EXPLICIT_ALLOW, rule_name
+        # Nothing matched, the request will be denied :(
+        return None, None
+
+    def resolve_cond_key(self, key, req):
+        """
+        Load the condition value from the request or environment.
+        See iam-ug.pdf document, page 1401.
+        """
+        return IamConditionKey[key](req)
+
+    def check_condition(self, statement, req):
+        """
+        Check the conditions from the statement are satisfied.
+
+        To be consistent with the "default deny" rule, for unverifiable
+        conditions, deny the request.
+
+        :param statement: the statement dict using the condition
+        :param req: the current request
+        """
+        cond = statement.get('Condition', {})
+        effect = statement['Effect']
+        for opname, operands in cond.items():
+            if IamConditionOp.get(opname, None) is None:
+                if effect == RE_ALLOW:
+                    self.logger.info(
+                        "IAM: condition operator %s not implemented. Since "
+                        "it is used in an 'allow' statement, consider the "
+                        "condition is not satisfied.", opname)
+                    return False
+                else:
+                    self.logger.info(
+                        "IAM: condition operator %s not implemented. Since "
+                        "it is used in a 'deny' statement, consider the "
+                        "condition is satisfied.", opname)
+                    continue
+            operator = IamConditionOp[opname]
+            for cond_key, values in operands.items():
+                if IamConditionKey.get(cond_key, None) is None:
+                    if effect == RE_ALLOW:
+                        self.logger.info(
+                            "IAM: condition %s not implemented. Since it is "
+                            "in an 'allow' statement, consider it is not "
+                            "satisfied.", cond_key)
+                        return False
+                    else:
+                        self.logger.info(
+                            "IAM: condition %s not implemented. Since it is "
+                            "in a 'deny' statement, consider it is satisfied.",
+                            cond_key)
+                        continue
+                cond_val = self.resolve_cond_key(cond_key, req)
+                if not operator(cond_val, values):
+                    # One of the conditions is not satisfied
+                    return False
+        # All conditions are satisfied
+        return True
+
+    def do_explicit_check(self, effect, action, req_res, req):
+        """
+        Lookup for an explicit deny or an explicit allow in the set of rules.
+
+        :param effect: one of RE_ALLOW or RE_DENY
+        :param req_res: the resource specified by the request
+        :returns: a tuple with a boolean telling of the rule has been matched
+            and the ID of the statement that matched.
+        """
+        for num, statement in enumerate(self._rules['Statement']):
+            # Statement ID is optional
+            sid = statement.get('Sid', 'statement-id-%d' % num)
+            self.logger.info("===> Checking statement %s (%s)",
+                             sid, statement['Effect'])
+            if statement['Effect'] != effect:
+                continue
+
+            # Check Action
+            for rule_action in statement['Action']:
+                if rule_action == action:
+                    # Found an exact match
+                    break
+                elif rule_action.endswith('*'):
+                    action_prefix = rule_action[:-1]
+                    if action.startswith(action_prefix):
+                        # Found a wildcard match
+                        break
+            else:
+                self.logger.info('Skipping %s, action %s is not in the list',
+                                 sid, action)
+                continue
+
+            for resource_str in statement['Resource']:
+                rule_res = IamResource(resource_str)
+
+                # check wildcards before everything else
+                if (rule_res.arn == ARN_WILDCARD_BUCKET and
+                        self.check_condition(statement, req)):
+                    self.logger.info('%s: matches everything', sid)
+                    return True, sid
+
+                # Ensure the requested and the current resource are of the
+                # same type. The specification says that a wildcard in the
+                # bucket name should not match objects (stop at first slash).
+                if rule_res.type != req_res.type:
+                    self.logger.info('%s: skip, resource types do not match',
+                                     sid)
+                    continue
+
+                # Do a case-sensitive match between the requested resource
+                # and the resource of the current rule.
+                if (fnmatchcase(req_res.arn, rule_res.arn) and
+                        self.check_condition(statement, req)):
+                    self.logger.info('%s: wildcard or exact match', sid)
+                    return True, sid
+
+        self.logger.info('No %s match found', effect)
+        return False, None
+
+    def match_explicit_deny(self, action, resource, req):
+        return self.do_explicit_check(RE_DENY, action, resource, req)
+
+    def match_explicit_allow(self, action, resource, req):
+        return self.do_explicit_check(RE_ALLOW, action, resource, req)
+
+
+def check_iam_access(action):
+    """
+    Check the specified action is allowed for the current user
+    on the resource defined by the request.
+    """
+
+    def real_check_iam_access(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            req = args[1]
+
+            # If there is no callback, IAM is disabled,
+            # thus we let everything pass through.
+            rules_cb = req.environ.get(IAM_RULES_CALLBACK)
+            if rules_cb is None:
+                return func(*args, **kwargs)
+
+            # Maybe ACLs authorized the request.
+            acl_allow = req.environ.get(ACL_EXPLICIT_ALLOW)
+
+            # IAM rules will be checked. We don't know yet if they allow
+            # the request, thus we consider they don't.
+            req.environ[IAM_EXPLICIT_ALLOW] = False
+
+            # FIXME(IAM): refine the callback parameters
+            matcher = rules_cb(req)
+            if matcher:
+                # FIXME(IAM): a * must be used as object name,
+                # not as wildcard in Resource below
+                if req.object_name:
+                    rsc = IamResource(req.container_name + '/' +
+                                      req.object_name)
+                elif req.container_name:
+                    rsc = IamResource(req.container_name)
+                else:
+                    rsc = None
+
+                effect, _sid = matcher(rsc, action, req)
+                # TODO(IAM): log sid, the ID of the matched rule statement
+                # An IAM rule explicitly denies the request.
+                if effect == EXPLICIT_DENY:
+                    raise AccessDenied()
+                # No IAM rule matched, and ACLs do not allow the request.
+                if effect is None and acl_allow is False:
+                    raise AccessDenied()
+
+                req.environ[IAM_EXPLICIT_ALLOW] = effect == EXPLICIT_ALLOW
+
+            # If there is no rule for this user, and ACLs did not grant
+            # access rights, don't let anything pass through.
+            elif acl_allow is False:
+                raise AccessDenied()
+            # else:
+            #    # acl_allow is None -> ACLs were not checked yet.
+
+            return func(*args, **kwargs)
+        return wrapper
+    return real_check_iam_access
+
+
+class IamMiddleware(object):
+    """
+    Base class for IAM implementations.
+
+    Subclasses must implement load_rules_for_user.
+    """
+
+    def __init__(self, app, conf):
+        self.app = app
+        self.logger = get_logger(conf)
+        self.connection = conf.get('connection')
+        maxsize = config_auto_int_value(conf.get('cache_size'), 1000)
+        maxtime = config_auto_int_value(conf.get('cache_ttl'), 30)
+        self._load_rules_matcher = LRUCache(maxsize=maxsize, maxtime=maxtime)(
+            self._build_rules_matcher)
+
+    def __call__(self, env, start_response):
+        # Put the rules callback in the request environment so middlewares
+        # further in the pipeline can call it when needed.
+        env[IAM_RULES_CALLBACK] = self.rules_callback
+        return self.app(env, start_response)
+
+    def load_rules_for_user(self, account, user_id):
+        """
+        Load rules for the authenticated user who did the request:
+        - from its own user policy,
+        - from its optional group policy,
+        - from its role policy.
+
+        Subclasses must implement this method.
+
+        :rtype: dict
+        :returns: a dictionary with at least a 'Statement' key, containing
+            a list of IAM statements.
+        """
+        raise NotImplementedError
+
+    def _build_rules_matcher(self, account, user_id):
+        """
+        Load IAM rules for the specified user, then build an IamRulesMatcher
+        instance.
+        """
+        rules = self.load_rules_for_user(account, user_id)
+        if rules:
+            self.logger.debug("Loading IAM rules for account=%s user_id=%s",
+                              account, user_id)
+            matcher = IamRulesMatcher(rules, logger=self.logger)
+            return matcher
+        else:
+            self.logger.debug("No IAM rule for account=%s user_id=%s",
+                              account, user_id)
+            return None
+
+    def rules_callback(self, s3req):
+        matcher = self._load_rules_matcher(s3req.account, s3req.user_id)
+        return matcher
+
+
+class StaticIamMiddleware(IamMiddleware):
+    """
+    Middleware loading IAM rules from a file.
+
+    This middleware must be placed before s3api in the pipeline.
+    The file must contain a JSON object, with one IAM policy document
+    per user ID.
+    """
+
+    def __init__(self, app, conf):
+        super(StaticIamMiddleware, self).__init__(app, conf)
+        if not self.connection:
+            self.logger.info('No IAM rules file')
+            self.rules = dict()
+        else:
+            import json
+            from six.moves.urllib.parse import urlparse
+            parsed = urlparse(self.connection)
+            if parsed.scheme and parsed.scheme != 'file':
+                raise ValueError("IAM: 'connection' must point to a JSON file")
+            self.logger.info('Loading IAM rules from %s', parsed.path)
+            with open(parsed.path, 'r') as rules_fd:
+                self.rules = json.load(rules_fd)
+
+    def load_rules_for_user(self, account, user_id):
+        rules = self.rules.get(user_id)
+        return rules
+
+
+def iam_is_enabled(env):
+    """
+    Check if IAM is enabled for this environment.
+    """
+    return env.get(IAM_RULES_CALLBACK) is not None
+
+
+def iam_explicit_allow(env):
+    """
+    Tell is IAM rules have already been checked, and allow the request
+    to be executed.
+
+    :returns: True is the request is allowed, False if the request is not
+        explicitly allowed, and None if the rules have not been checked yet.
+    """
+    return env.get(IAM_EXPLICIT_ALLOW)
+
+
+def filter_factory(global_conf, **local_config):
+    conf = global_conf.copy()
+    conf.update(local_config)
+
+    def factory(app):
+        return StaticIamMiddleware(app, conf)
+    return factory

--- a/swift/common/middleware/s3api/oioiam.py
+++ b/swift/common/middleware/s3api/oioiam.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2020 OpenStack Foundation.
+# Copyright (C) 2020 OpenIO SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from cliff import show
+from six import string_types
+from six.moves.urllib_parse import parse_qs, urlparse
+
+from oio.common.redis_conn import RedisConnection, catch_service_errors
+from swift.common.middleware.s3api.iam import IamMiddleware, \
+    StaticIamMiddleware
+
+
+class RedisIamDb(object):
+    """
+    High-level API to save IAM rules in a Redis database.
+    """
+
+    def __init__(self, key_prefix='IAM:', **redis_kwargs):
+        self.key_prefix = key_prefix
+        self.redis = RedisConnection(**redis_kwargs)
+
+    def key_for_account(self, account):
+        """
+        Get the Redis key to the hash holding IAM rules
+        for all users of the specified account.
+        """
+        return self.key_prefix + 'account:' + account
+
+    @catch_service_errors
+    def load_rules_str_for_user(self, account, user):
+        """
+        Load IAM rules for the specified user.
+
+        :rtype: str
+        """
+        acct_key = self.key_for_account(account)
+        rules = self.redis.conn_slave.hget(acct_key, user)
+        return rules
+
+    @catch_service_errors
+    def save_rules_str_for_user(self, account, user, rules):
+        """
+        Save IAM rules for the specified user.
+
+        :param rules: JSON-formatted string
+        :type rules: str
+        """
+        if not isinstance(rules, string_types):
+            raise TypeError("rules parameter must be a string")
+        try:
+            rules_obj = json.loads(rules)
+            # Strip spaces and new lines
+            rules = json.dumps(rules_obj, separators=(',', ':'))
+        except ValueError as err:
+            raise ValueError('rules is not JSON-formatted: %s' % err)
+        acct_key = self.key_for_account(account)
+        self.redis.conn.hset(acct_key, user, rules)
+
+
+class RedisIamMiddleware(IamMiddleware, RedisIamDb):
+    """
+    Middleware loading IAM rules from a Redis database.
+
+    There is one hash per account.
+    Each field of the hash holds the IAM rules document for one user.
+
+    Examples (Keystone's style account names):
+        IAM:account:AUTH_d1bcefa04c41403c92f4ee5634559e4c
+            admin:admin
+                '{"Statement": [...]}'
+        IAM:account:AUTH_acc6af49dcfe41799323b3b7902ae1b0
+            demo:demo
+                '{"Statement": [...]}'
+            demo:demo2
+                '{"Statement": [...]}'
+    """
+
+    def __init__(self, app, conf):
+        super(RedisIamMiddleware, self).__init__(app, conf)
+        RedisIamDb.__init__(self, **conf)
+
+    def load_rules_for_user(self, account, user):
+        rules = self.load_rules_str_for_user(account, user)
+        if not rules:
+            return None
+        return json.loads(rules)
+
+
+class IamCommandMixin(object):
+    """
+    Add IAM-related arguments to a cliff command.
+    """
+
+    default_connection = 'redis://127.0.0.1:6379'
+
+    def patch_parser(self, parser):
+        parser.add_argument('--connection',
+                            help=("Tell how to connect to the IAM database. "
+                                  "This overrides the 'iam.connection' "
+                                  "parameter defined in the namespace "
+                                  "configuration file. Defaults to '%s' if "
+                                  "neither parameter is set." %
+                                  self.default_connection))
+        parser.add_argument('account',
+                            help=("The account the user belongs to. "
+                                  "Usually 'AUTH_' followed by either the "
+                                  "Keystone project ID, or the clear account "
+                                  "name when using tempauth."))
+        parser.add_argument('user',
+                            help=("The ID of the user, as seen by the swift "
+                                  "gateway. Usually in the form "
+                                  "'project_name:user_name'."))
+
+    def pretty_print_rules(self, rules):
+        """
+        :param rules: JSON-formatted string
+        :returns: the pretty-printed version of the rules
+        """
+        return json.dumps(json.loads(rules), sort_keys=True, indent=4)
+
+    def get_db(self, parsed_args):
+        if parsed_args.connection is None:
+            parsed_args.connection = self.app.client_manager.sds_conf.get(
+                'iam.connection', self.default_connection)
+        if parsed_args.connection == self.default_connection:
+            self.logger.warn('Using the default connection (%s) is probably '
+                             'not what you want to do.',
+                             self.default_connection)
+        scheme, netloc, kwargs = parse_conn_str(parsed_args.connection)
+        if scheme == 'redis+sentinel':
+            kwargs['sentinel_hosts'] = netloc
+        else:
+            kwargs['host'] = netloc
+        return RedisIamDb(**kwargs)
+
+    @property
+    def logger(self):
+        return self.app.client_manager.logger
+
+
+class IamGetUserPolicy(IamCommandMixin, show.ShowOne):
+    """
+    Get the IAM policy for the specified user.
+    """
+
+    columns = ('account', 'user', 'policy')
+
+    def get_parser(self, prog_name):
+        parser = super(IamGetUserPolicy, self).get_parser(prog_name)
+        self.patch_parser(parser)
+        return parser
+
+    def take_action(self, parsed_args):
+        iamdb = self.get_db(parsed_args)
+        rules = iamdb.load_rules_str_for_user(parsed_args.account,
+                                              parsed_args.user)
+        if not rules:
+            # FIXME(IAM): change return code?
+            rules = 'null'
+        elif parsed_args.formatter == 'table':
+            rules = self.pretty_print_rules(rules)
+        return self.columns, [parsed_args.account, parsed_args.user, rules]
+
+
+class IamSetUserPolicy(IamCommandMixin, show.ShowOne):
+    """
+    Set the IAM policy for the specified user.
+    """
+
+    columns = ('account', 'user', 'policy')
+
+    def get_parser(self, prog_name):
+        parser = super(IamSetUserPolicy, self).get_parser(prog_name)
+        self.patch_parser(parser)
+        parser.add_argument('policy',
+                            help=("User policy string (JSON), or path to a "
+                                  "file containing the policy "
+                                  "(use the --from-file option)."))
+        parser.add_argument('--from-file',
+                            action='store_true',
+                            help=("Consider 'policy' as the path to a JSON "
+                                  "file. Use '-' to read from stdin."))
+        return parser
+
+    def take_action(self, parsed_args):
+        if parsed_args.from_file:
+            if parsed_args.policy == '-':
+                from sys import stdin
+                rules = stdin.read()
+            else:
+                with open(parsed_args.policy, 'r') as rules_f:
+                    rules = rules_f.read()
+        else:
+            rules = parsed_args.policy
+        iamdb = self.get_db(parsed_args)
+        iamdb.save_rules_str_for_user(parsed_args.account,
+                                      parsed_args.user,
+                                      rules)
+        if parsed_args.formatter == 'table':
+            rules = self.pretty_print_rules(rules)
+        return self.columns, [parsed_args.account, parsed_args.user, rules]
+
+
+def parse_conn_str(conn_str):
+    """
+    Get the connection scheme, network host (or hosts)
+    and a dictionary of extra arguments from a connection string.
+
+    Example:
+    >>> parse_conn_str('redis://10.0.1.27:666,10.0.1.25:667?opt1=val1&opt2=5')
+    ('redis', '10.0.1.27:666,10.0.1.25:667', {'opt1': 'val1', 'opt2': '5'})
+    """
+    scheme, netloc, _, _, query, _ = urlparse(conn_str)
+    kwargs = {k: ','.join(v) for k, v in parse_qs(query).items()}
+    return scheme, netloc, kwargs
+
+
+def filter_factory(global_conf, **local_config):
+    conf = global_conf.copy()
+    conf.update(local_config)
+    conn_str = conf.get('connection')
+    if not conn_str:
+        try:
+            from oio.common.configuration import load_namespace_conf
+            ns_conf = load_namespace_conf(conf['sds_namespace'], failsafe=True)
+            conn_str = ns_conf['iam.connection']
+        except Exception as err:
+            raise ValueError("IAM: Please set either 'connection' in IAM's "
+                             "configuration section or 'iam.connection' in "
+                             "the namespace configuration file. %s" % err)
+    scheme, netloc, kwargs = parse_conn_str(conn_str)
+    conf.update(kwargs)
+
+    if scheme in ('redis', 'redis+sentinel'):
+        klass = RedisIamMiddleware
+        if scheme == 'redis+sentinel':
+            conf['sentinel_hosts'] = netloc
+        else:
+            conf['host'] = netloc
+    elif scheme == 'file':
+        klass = StaticIamMiddleware
+    else:
+        raise ValueError('IAM: unknown scheme: %s' % scheme)
+
+    def factory(app):
+        return klass(app, conf)
+    return factory

--- a/test/unit/common/middleware/s3api/test_bucket.py
+++ b/test/unit/common/middleware/s3api/test_bucket.py
@@ -116,7 +116,7 @@ class TestS3ApiBucket(S3ApiTestCase):
             json.dumps(object_list_subdir))
         self.swift.register(
             'GET',
-            '/v1/AUTH_test/subdirs?delimiter=/&limit=3',
+            '/v1/AUTH_test/subdirs?delimiter=/&format=json&limit=3',
             swob.HTTPOk, {}, json.dumps([
                 {'subdir': 'nothing/'},
                 {'subdir': u'but-\u062a/'},
@@ -1008,7 +1008,7 @@ class TestS3ApiBucket(S3ApiTestCase):
         ]
         self.assertEqual(expected, discovered)
         self.assertEqual(self.swift.calls, [
-            ('GET', normalize_path('/v1/AUTH_test/junk?'
+            ('GET', normalize_path('/v1/AUTH_test/junk?format=json&'
              'limit=1001&marker=rose&version_marker=null&versions=')),
         ])
 
@@ -1073,7 +1073,7 @@ class TestS3ApiBucket(S3ApiTestCase):
 
         self.assertEqual(self.swift.calls, [
             ('GET', normalize_path('/v1/AUTH_test/junk'
-             '?limit=1001&prefix=subdir/&versions=')),
+             '?format=json&limit=1001&prefix=subdir/&versions=')),
         ])
 
     @s3acl

--- a/test/unit/common/middleware/s3api/test_bucket_db.py
+++ b/test/unit/common/middleware/s3api/test_bucket_db.py
@@ -161,7 +161,7 @@ class TestSwift3BucketDb(S3ApiTestCase):
               "hash": "0000",
               "bytes": 0}]).encode('utf-8')
         self.swift.register('GET',
-                            '/v1/AUTH_test/bucket?limit=1001',
+                            '/v1/AUTH_test/bucket?format=json&limit=1001',
                             swob.HTTPOk, {}, expected_body)
         # Then do a call with 'test2' account, that should be changed
         # to 'test' by the middleware (because the bucket 'bucket' belongs

--- a/test/unit/common/middleware/s3api/test_iam.py
+++ b/test/unit/common/middleware/s3api/test_iam.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2020 OpenStack Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest import TestCase
+from mock import MagicMock
+
+from swift.common.middleware.s3api.exception import IAMException
+from swift.common.middleware.s3api.iam import IamResource, IamRulesMatcher, \
+    EXPLICIT_DENY, EXPLICIT_ALLOW
+
+
+class TestS3Iam(TestCase):
+
+    def test_invalid_action_for_resource_type(self):
+        rsc = IamResource("customer")  # Bucket resource
+        self.assertRaises(IAMException,
+                          IamRulesMatcher({}), rsc, "s3:GetObject")
+
+    def test_action_wildcard(self):
+        rules = json.loads("""{
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:Get*",
+                        "s3:List*"
+                    ],
+                    "Resource": ["*"],
+                    "Sid": "ReadOnly"
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        check = IamRulesMatcher(rules)
+        bucket_res = IamResource("customer")
+        object_res = IamResource("customer/somefile")
+        self.assertEqual((EXPLICIT_ALLOW, 'ReadOnly'),
+                         check(object_res, "s3:GetObject"))
+        self.assertEqual((EXPLICIT_ALLOW, 'ReadOnly'),
+                         check(bucket_res, "s3:GetBucketLocation"))
+        self.assertEqual((EXPLICIT_ALLOW, 'ReadOnly'),
+                         check(bucket_res, "s3:ListBucket"))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:CreateBucket"))
+        self.assertEqual((None, None),
+                         check(object_res, "s3:PutObject"))
+
+    def test_explicit_allow(self):
+        rules = json.loads("""{
+            "Statement": [
+                {
+                    "Action": ["s3:GetObject"],
+                    "Effect": "Allow",
+                    "Resource": [
+                        "arn:aws:s3:::customer/dede"
+                    ],
+                    "Sid": "AllowGetSpecificObject"
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        rsc = IamResource("customer/dede")
+        check = IamRulesMatcher(rules)
+        self.assertEqual((EXPLICIT_ALLOW, 'AllowGetSpecificObject'),
+                         check(rsc, "s3:GetObject"))
+        forbidden = IamResource("customer/somefile")
+        self.assertEqual((None, None),
+                         check(forbidden, "s3:GetObject"))
+
+    def test_explicit_deny(self):
+        rules = json.loads("""{
+            "Statement": [
+                {
+                    "Action": ["s3:*"],
+                    "Effect": "Allow",
+                    "Resource": ["*"],
+                    "Sid": "DefaultFullAccess"
+                },
+                {
+                    "Action": ["s3:*"],
+                    "Effect": "Deny",
+                    "Resource": [
+                        "arn:aws:s3:::customer",
+                        "arn:aws:s3:::customer/*"
+                    ],
+                    "Sid": "DenyCustomerBucketAndObjects"
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        rsc = IamResource("customer/dede")
+        check = IamRulesMatcher(rules)
+        self.assertEqual((EXPLICIT_DENY, 'DenyCustomerBucketAndObjects'),
+                         check(rsc, "s3:GetObject"))
+
+        rsc = IamResource("customer")
+        check = IamRulesMatcher(rules)
+        self.assertEqual((EXPLICIT_DENY, 'DenyCustomerBucketAndObjects'),
+                         check(rsc, "s3:ListBucketMultipartUploads"))
+
+    def test_explicit_wildcard_bucket_path(self):
+        rules = json.loads("""
+        {
+            "Statement": [
+                {
+                    "Action": ["s3:GetObject"],
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:s3:::*/*"],
+                    "Sid": "AllowWildcard-2"
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        rsc = IamResource("bucket/dede")
+        check = IamRulesMatcher(rules)
+        self.assertEqual((EXPLICIT_ALLOW, 'AllowWildcard-2'),
+                         check(rsc, "s3:GetObject"))
+
+    def test_explicit_wildcard_path(self):
+        rules = json.loads("""
+        {
+            "Statement": [
+                {
+                    "Action": ["s3:GetObject"],
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:s3:::bucket/*"],
+                    "Sid": "AllowWildcard-3"
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        rsc = IamResource("bucket/dede")
+        check = IamRulesMatcher(rules)
+        self.assertEqual((EXPLICIT_ALLOW, 'AllowWildcard-3'),
+                         check(rsc, "s3:GetObject"))
+
+    def test_bucket_and_object_wildcards(self):
+        rules = json.loads("""
+        {
+            "Statement": [
+                {
+                    "Action": [
+                        "s3:*"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": [
+                        "arn:aws:s3:::s3rt*"
+                    ],
+                    "Sid": "S3RoundtripBucket"
+                },
+                {
+                    "Action": [
+                        "s3:*"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": [
+                        "arn:aws:s3:::s3rt*/*"
+                    ],
+                    "Sid": "S3RoundtripObjects"
+                }
+            ]
+        }
+        """)
+        check = IamRulesMatcher(rules)
+        bkt_res = IamResource("s3rt-test")
+        self.assertEqual((EXPLICIT_ALLOW, 'S3RoundtripBucket'),
+                         check(bkt_res, "s3:CreateBucket"))
+        obj_res = IamResource("s3rt-test/hosts")
+        self.assertEqual((EXPLICIT_ALLOW, 'S3RoundtripObjects'),
+                         check(obj_res, "s3:PutObject"))
+
+        obj_res2 = IamResource("s3ru-test/hosts")
+        self.assertEqual((None, None),
+                         check(obj_res2, "s3:PutObject"))
+
+    def test_statement_condition_stringequals(self):
+        rules = json.loads("""{
+            "Statement": [
+                {
+                    "Sid": "AllowRootAndHomeListingOfCompanyBucket",
+                    "Action": ["s3:ListBucket"],
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:s3:::my-company"],
+                    "Condition": {
+                        "StringEquals": {
+                            "s3:prefix": ["", "home/", "home/David"],
+                            "s3:delimiter": ["/"]
+                        }
+                    }
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        check = IamRulesMatcher(rules)
+        bucket_res = IamResource("my-company")
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={})))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': ''})))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': 'home/Michael',
+                                                 'delimiter': '/'})))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': 'home/David',
+                                                 'delimiter': ':'})))
+        self.assertEqual(('ALLOW', 'AllowRootAndHomeListingOfCompanyBucket'),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': 'home/David',
+                                                 'delimiter': '/'})))
+
+    def test_statement_condition_stringlike(self):
+        rules = json.loads("""{
+            "Statement": [
+                {
+                    "Sid": "AllowListingOfUserFolder",
+                    "Action": ["s3:ListBucket"],
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:s3:::my-company"],
+                    "Condition": {
+                        "StringLike": {"s3:prefix": ["home/David/*"]}
+                    }
+                }
+            ],
+            "Version": "2012-10-17"
+        }
+        """)
+        check = IamRulesMatcher(rules)
+        bucket_res = IamResource("my-company")
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={})))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': ''})))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': 'home/Michael/'})))
+        self.assertEqual((None, None),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': 'home/David',
+                                                 'delimiter': ':'})))
+        self.assertEqual(('ALLOW', 'AllowListingOfUserFolder'),
+                         check(bucket_res, "s3:ListBucket",
+                               MagicMock(params={'prefix': 'home/David/'})))
+        self.assertEqual(
+            ('ALLOW', 'AllowListingOfUserFolder'),
+            check(bucket_res, "s3:ListBucket",
+                  MagicMock(params={'prefix': 'home/David/foo/'})))


### PR DESCRIPTION
IAM rules are loaded from a file by the "iam" middleware. Then any request controller can call this middleware with the help of the `check_iam_access` decorator, which will raise `AccessDenied` in case the operation is not allowed for the authenticated user.

Change-Id: I04739d7e44497bb25f64c60c0a6a2f77fc2dfc0b
Co-authored-by: Michael Bonfils <michael.bonfils@ovhcloud.com>