### PR TITLE
Handle x-amz-tagging header while creating objects

### DIFF
--- a/swift/common/middleware/s3api/controllers/multi_upload.py
+++ b/swift/common/middleware/s3api/controllers/multi_upload.py
@@ -80,6 +80,8 @@ from six.moves.urllib.parse import quote, urlparse
 
 from swift.common.middleware.s3api.controllers.base import Controller, \
     bucket_operation, object_operation, check_container_existence
+from swift.common.middleware.s3api.controllers.tagging import \
+    HTTP_HEADER_TAGGING_KEY, OBJECT_TAGGING_HEADER, tagging_header_to_xml
 from swift.common.middleware.s3api.s3response import InvalidArgument, \
     ErrorResponse, MalformedXML, BadDigest, \
     InvalidPart, BucketAlreadyExists, EntityTooSmall, InvalidPartOrder, \
@@ -553,6 +555,11 @@ class UploadsController(Controller):
 
         obj = '%s/%s' % (req.object_name, upload_id)
 
+        if HTTP_HEADER_TAGGING_KEY in req.headers:
+            tagging = tagging_header_to_xml(
+                req.headers.get(HTTP_HEADER_TAGGING_KEY))
+            req.headers[OBJECT_TAGGING_HEADER] = tagging
+
         req.headers.pop('Etag', None)
         req.headers.pop('Content-Md5', None)
         req.environ['oio.ephemeral_object'] = True
@@ -744,6 +751,10 @@ class UploadController(Controller):
             _key = key.lower()
             if _key.startswith('x-amz-meta-'):
                 headers['x-object-meta-' + _key[11:]] = val
+        for key, val in resp.sysmeta_headers.items():
+            _key = key.lower()
+            if _key == OBJECT_TAGGING_HEADER.lower():
+                headers[key] = val
 
         hct_header = sysmeta_header('object', 'has-content-type')
         if resp.sysmeta_headers.get(hct_header) == 'yes':

--- a/swift/common/middleware/s3api/controllers/obj.py
+++ b/swift/common/middleware/s3api/controllers/obj.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2014 OpenStack Foundation.
+# Copyright (c) 2010-2020 OpenStack Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ from swift.common.middleware.versioned_writes.object_versioning import \
     DELETE_MARKER_CONTENT_TYPE
 from swift.common.middleware.s3api.utils import S3Timestamp, sysmeta_header
 from swift.common.middleware.s3api.controllers.base import Controller
+from swift.common.middleware.s3api.controllers.tagging import \
+    HTTP_HEADER_TAGGING_KEY, OBJECT_TAGGING_HEADER, tagging_header_to_xml
 from swift.common.middleware.s3api.s3response import S3NotImplemented, \
     InvalidRange, NoSuchKey, NoSuchVersion, InvalidArgument, HTTPNoContent, \
     PreconditionFailed
@@ -170,6 +172,12 @@ class ObjectController(Controller):
             raise InvalidArgument('x-amz-copy-source-range',
                                   req.headers['X-Amz-Copy-Source-Range'],
                                   'Illegal copy header')
+
+        if HTTP_HEADER_TAGGING_KEY in req.headers:
+            tagging = tagging_header_to_xml(
+                req.headers.pop(HTTP_HEADER_TAGGING_KEY))
+            req.headers[OBJECT_TAGGING_HEADER] = tagging
+
         req.check_copy_source(self.app)
         if not req.headers.get('Content-Type'):
             # can't setdefault because it can be None for some reason

--- a/swift/common/middleware/s3api/s3request.py
+++ b/swift/common/middleware/s3api/s3request.py
@@ -843,9 +843,6 @@ class S3Request(swob.Request):
             raise S3NotImplemented('Transfering payloads in multiple chunks '
                                    'using aws-chunked is not supported.')
 
-        if 'x-amz-tagging' in self.headers:
-            raise S3NotImplemented('Object tagging is not supported.')
-
     @property
     def body(self):
         """

--- a/test/unit/common/middleware/s3api/test_obj.py
+++ b/test/unit/common/middleware/s3api/test_obj.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 OpenStack Foundation
+# Copyright (c) 2014-2020 OpenStack Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ from swift.common.middleware.proxy_logging import ProxyLoggingMiddleware
 
 from test.unit.common.middleware.s3api import S3ApiTestCase
 from test.unit.common.middleware.s3api.test_s3_acl import s3acl
+from swift.common.middleware.s3api.controllers import tagging
 from swift.common.middleware.s3api.subresource import ACL, User, encode_acl, \
     Owner, Grant
 from swift.common.middleware.s3api.etree import fromstring
@@ -1684,6 +1685,33 @@ class TestS3ApiObj(S3ApiTestCase):
         status, headers, body = self._test_object_copy_for_s3acl(
             'test:write', 'READ', src_path='')
         self.assertEqual(status.split()[0], '400')
+
+    @s3acl
+    def test_object_PUT_tagging(self):
+        etag = self.response_headers['etag']
+        content_md5 = binascii.b2a_base64(binascii.a2b_hex(etag)).strip()
+
+        req = Request.blank(
+            '/bucket/object',
+            environ={'REQUEST_METHOD': 'PUT'},
+            headers={'Authorization': 'AWS test:tester:hmac',
+                     'x-amz-storage-class': 'STANDARD',
+                     'Content-MD5': content_md5,
+                     'Date': self.get_date_header(),
+                     'x-amz-tagging': 'a=&b='},
+            body=self.object_body)
+        req.date = datetime.now()
+        req.content_type = 'text/plain'
+        status, headers, _body = self.call_s3api(req)
+        print(_body)
+        self.assertEqual(status.split()[0], '200')
+        # Check that s3api returns an etag header.
+        self.assertEqual(headers['etag'], '"%s"' % etag)
+
+        _, _, headers = self.swift.calls_with_headers[-1]
+        # Check that s3api converts a Content-MD5 header into an etag.
+        self.assertEqual(headers['etag'], etag)
+        self.assertIn(tagging.OBJECT_TAGGING_HEADER, headers)
 
 
 class TestS3ApiObjNonUTC(TestS3ApiObj):

--- a/test/unit/common/middleware/s3api/test_s3api.py
+++ b/test/unit/common/middleware/s3api/test_s3api.py
@@ -677,9 +677,6 @@ class TestS3ApiMiddleware(S3ApiTestCase):
                                       'STREAMING-AWS4-HMAC-SHA256-PAYLOAD')
         self._test_unsupported_header('x-amz-decoded-content-length')
 
-    def test_object_tagging(self):
-        self._test_unsupported_header('x-amz-tagging')
-
     def _test_unsupported_resource(self, resource):
         req = Request.blank('/error?' + resource,
                             environ={'REQUEST_METHOD': 'GET',


### PR DESCRIPTION
When an object is uploaded with the x-amz-tagging header, set the specified tag set on the object (as does the PutObjectTagging operation).